### PR TITLE
M3 Phase 0: Backend prerequisites for React UI

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -1,6 +1,6 @@
 """Pydantic request/response models for pipeline control API."""
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 
 # -- Requests --
@@ -20,6 +20,25 @@ class SetPhaseRequest(BaseModel):
 class UpdateConfigRequest(BaseModel):
     confidence_threshold: float | None = None
     inference_interval: int | None = None
+
+
+class EntryExitLine(BaseModel):
+    label: str
+    start: tuple[float, float]
+    end: tuple[float, float]
+
+
+class SiteConfigRequest(BaseModel):
+    site_id: str
+    roi_polygon: list[tuple[float, float]]
+    entry_exit_lines: dict[str, EntryExitLine] = {}
+
+    @field_validator("roi_polygon")
+    @classmethod
+    def polygon_min_vertices(cls, v):
+        if len(v) < 3:
+            raise ValueError("ROI polygon must have at least 3 vertices")
+        return v
 
 
 # -- Responses --

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -10,6 +10,7 @@ from backend.api.models import (
     PhaseResponse,
     RemoveChannelRequest,
     SetPhaseRequest,
+    SiteConfigRequest,
     StatusResponse,
     UpdateConfigRequest,
 )
@@ -19,6 +20,27 @@ from backend.pipeline.alerts import AlertStore
 from backend.pipeline.protocol import ChannelPhase, PipelineBackend
 
 router = APIRouter()
+
+
+@router.get("/channels")
+def list_channels(
+    request: Request,
+    backend: PipelineBackend = Depends(get_backend),
+    alert_store: AlertStore = Depends(get_alert_store),
+):
+    if not request.app.state.pipeline_started:
+        return {"channels": [], "pipeline_started": False}
+    channels = []
+    for channel_id, source in backend.channels.items():
+        phase = backend.get_channel_phase(channel_id)
+        alert_count = alert_store.count_by_channel(channel_id)
+        channels.append({
+            "channel_id": channel_id,
+            "source": source,
+            "phase": phase.value,
+            "alert_count": alert_count,
+        })
+    return {"channels": channels, "pipeline_started": True}
 
 
 @router.post("/pipeline/start", response_model=StatusResponse)
@@ -92,6 +114,7 @@ def remove_channel(
 def set_channel_phase(
     channel_id: int,
     body: SetPhaseRequest,
+    request: Request,
     backend: PipelineBackend = Depends(get_backend),
 ):
     try:
@@ -102,9 +125,16 @@ def set_channel_phase(
             status_code=422, detail=f"Invalid phase. Must be one of: {valid}"
         )
     try:
+        previous = backend.get_channel_phase(channel_id)
         backend.set_channel_phase(channel_id, phase)
     except KeyError:
         raise HTTPException(status_code=404, detail="Channel not found")
+    request.app.state.ws.enqueue({
+        "type": "phase_changed",
+        "channel": channel_id,
+        "phase": phase.value,
+        "previous_phase": previous.value,
+    })
     return PhaseResponse(status="ok", phase=phase.value)
 
 
@@ -124,9 +154,10 @@ def update_config(
 def list_alerts(
     limit: int = Query(default=50, ge=1, le=200),
     type: str | None = Query(default=None),
+    channel: int | None = Query(default=None),
     alert_store: AlertStore = Depends(get_alert_store),
 ):
-    return alert_store.get_alerts(limit=limit, alert_type=type)
+    return alert_store.get_alerts(limit=limit, alert_type=type, channel=channel)
 
 
 @router.get("/alert/{alert_id}")
@@ -152,19 +183,15 @@ def get_snapshot(
 
 
 @router.post("/site/config", response_model=StatusResponse)
-def save_site(body: dict):
-    site_id = body.get("site_id")
-    if not site_id:
-        raise HTTPException(status_code=422, detail="site_id is required")
-    roi = [tuple(p) for p in body.get("roi_polygon", [])]
-    if len(roi) < 3:
-        raise HTTPException(
-            status_code=422, detail="ROI polygon must have at least 3 vertices"
-        )
+def save_site(body: SiteConfigRequest):
+    entry_exit = {
+        k: {"label": v.label, "start": list(v.start), "end": list(v.end)}
+        for k, v in body.entry_exit_lines.items()
+    }
     config = SiteConfig(
-        site_id=site_id,
-        roi_polygon=roi,
-        entry_exit_lines=body.get("entry_exit_lines", {}),
+        site_id=body.site_id,
+        roi_polygon=list(body.roi_polygon),
+        entry_exit_lines=entry_exit,
     )
     site_config_mod.save_site_config(config, site_config_mod.SITES_DIR)
     return StatusResponse(status="saved")

--- a/backend/api/websocket.py
+++ b/backend/api/websocket.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import queue
+import time
 from typing import Any
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
@@ -23,10 +24,14 @@ class WsBroadcaster:
     """
 
     def __init__(self):
-        # (websocket, channel_filter) — None means all channels
-        self._clients: list[tuple[WebSocket, set[int] | None]] = []
+        # (websocket, channel_filter, type_filter) — None means all
+        self._clients: list[tuple[WebSocket, set[int] | None, set[str] | None]] = []
         self._queue: queue.Queue[dict[str, Any]] = queue.Queue()
         self._drain_task: asyncio.Task | None = None
+        # Stats tracking for stats_update (per channel)
+        self._stats_last_emit: dict[int, float] = {}  # channel_id -> last emit time
+        self._stats_frame_count: dict[int, int] = {}  # channel_id -> frames since last emit
+        self._stats_inference_ms_sum: dict[int, float] = {}  # channel_id -> sum for avg
 
     async def start(self) -> None:
         """Start the background drain task."""
@@ -42,14 +47,19 @@ class WsBroadcaster:
                 pass
             self._drain_task = None
 
-    async def connect(self, ws: WebSocket, channels: set[int] | None) -> None:
+    async def connect(
+        self,
+        ws: WebSocket,
+        channels: set[int] | None,
+        types: set[str] | None = None,
+    ) -> None:
         """Accept a WebSocket and register it for broadcasts."""
         await ws.accept()
-        self._clients.append((ws, channels))
+        self._clients.append((ws, channels, types))
 
     def disconnect(self, ws: WebSocket) -> None:
         """Remove a WebSocket from the client list."""
-        self._clients = [(w, c) for w, c in self._clients if w is not ws]
+        self._clients = [(w, c, t) for w, c, t in self._clients if w is not ws]
 
     def enqueue(self, message: dict) -> None:
         """Thread-safe: put a message on the broadcast queue."""
@@ -58,7 +68,7 @@ class WsBroadcaster:
     # -- Pipeline callbacks (called from pipeline thread) --
 
     def on_frame(self, result: FrameResult) -> None:
-        """Convert FrameResult to frame_data WS message."""
+        """Convert FrameResult to frame_data WS message and emit stats_update."""
         msg = {
             "type": "frame_data",
             "channel": result.channel_id,
@@ -76,6 +86,7 @@ class WsBroadcaster:
             ],
         }
         self.enqueue(msg)
+        self._maybe_emit_stats(result)
 
     def on_alert(self, alert: dict) -> None:
         """Forward an alert dict (already has 'type' field) to WS clients."""
@@ -84,6 +95,35 @@ class WsBroadcaster:
     def on_track_ended(self, track: dict) -> None:
         """Forward a track_ended dict to WS clients."""
         self.enqueue(track)
+
+    def _maybe_emit_stats(self, result: FrameResult) -> None:
+        """Emit stats_update every 1 second per channel."""
+        ch = result.channel_id
+        now = time.monotonic()
+        last = self._stats_last_emit.get(ch, 0.0)
+        self._stats_frame_count[ch] = self._stats_frame_count.get(ch, 0) + 1
+        self._stats_inference_ms_sum[ch] = (
+            self._stats_inference_ms_sum.get(ch, 0.0) + result.inference_ms
+        )
+        if now - last >= 1.0:
+            frames = self._stats_frame_count[ch]
+            elapsed = now - last if last > 0 else 1.0
+            fps = round(frames / elapsed, 1)
+            avg_inference = round(
+                self._stats_inference_ms_sum[ch] / frames, 1
+            ) if frames > 0 else 0.0
+            self.enqueue({
+                "type": "stats_update",
+                "channel": ch,
+                "fps": fps,
+                "active_tracks": len(result.detections),
+                "inference_ms": avg_inference,
+                "phase": result.phase,
+                "idle_mode": result.idle_mode,
+            })
+            self._stats_last_emit[ch] = now
+            self._stats_frame_count[ch] = 0
+            self._stats_inference_ms_sum[ch] = 0.0
 
     # -- Internal --
 
@@ -100,14 +140,20 @@ class WsBroadcaster:
     async def _broadcast(self, message: dict) -> None:
         """Send a message to all matching connected clients."""
         msg_channel = message.get("channel")
+        msg_type = message.get("type")
         text = json.dumps(message)
         dead: list[WebSocket] = []
-        for ws, channel_filter in self._clients:
+        for ws, channel_filter, type_filter in self._clients:
             # Channel filtering: skip if client subscribed to specific channels
             # and this message has a channel that doesn't match.
             # Messages without a channel (e.g. pipeline_event) go to everyone.
             if channel_filter is not None and msg_channel is not None:
                 if msg_channel not in channel_filter:
+                    continue
+            # Type filtering: skip if client subscribed to specific types
+            # and this message type doesn't match.
+            if type_filter is not None and msg_type is not None:
+                if msg_type not in type_filter:
                     continue
             try:
                 await ws.send_text(text)
@@ -128,7 +174,13 @@ async def websocket_endpoint(ws: WebSocket):
     if channels_param:
         channel_filter = {int(c) for c in channels_param.split(",") if c.strip()}
 
-    await broadcaster.connect(ws, channel_filter)
+    # Parse optional type filter from query params
+    types_param = ws.query_params.get("types")
+    type_filter: set[str] | None = None
+    if types_param:
+        type_filter = {t.strip() for t in types_param.split(",") if t.strip()}
+
+    await broadcaster.connect(ws, channel_filter, type_filter)
     try:
         while True:
             # Keep connection alive — client doesn't send meaningful data

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,7 @@ import os
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from backend.api.mjpeg import MjpegBroadcaster
 from backend.api.mjpeg import router as mjpeg_router
@@ -42,6 +43,12 @@ def create_app(backend: str = "deepstream") -> FastAPI:
         raise ValueError(f"Unknown backend: {backend}")
 
     app = FastAPI(title="Vehicle Tracker", lifespan=lifespan)
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["http://localhost:5173"],
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
     app.state.backend = pipeline_backend
     app.state.alert_store = AlertStore()
     app.state.pipeline_started = False

--- a/backend/pipeline/alerts.py
+++ b/backend/pipeline/alerts.py
@@ -67,6 +67,7 @@ class AlertStore:
                     "frame": f["frame"],
                     "bbox": list(f["bbox"]),
                     "centroid": list(f["centroid"]),
+                    "timestamp_ms": f.get("timestamp_ms", 0),
                 }
                 for f in per_frame_data
             ],
@@ -126,6 +127,7 @@ class AlertStore:
         self,
         limit: int = 50,
         alert_type: str | None = None,
+        channel: int | None = None,
     ) -> list[dict]:
         """Get alert summaries (newest first, paginated).
 
@@ -140,6 +142,8 @@ class AlertStore:
                 continue
             if alert_type and alert["type"] != alert_type:
                 continue
+            if channel is not None and alert["channel"] != channel:
+                continue
             result.append(self._to_summary(alert))
             if len(result) >= limit:
                 break
@@ -151,6 +155,10 @@ class AlertStore:
         if alert is None:
             return None
         return self._to_summary(alert)
+
+    def count_by_channel(self, channel: int) -> int:
+        """Count alerts for a specific channel."""
+        return sum(1 for a in self._alerts.values() if a["channel"] == channel)
 
     def clear_channel(self, channel: int) -> None:
         """Remove all alerts for a channel (Phase 4 teardown)."""

--- a/backend/pipeline/protocol.py
+++ b/backend/pipeline/protocol.py
@@ -39,6 +39,9 @@ class FrameResult:
     timestamp_ms: int
     detections: list[Detection]
     annotated_jpeg: bytes | None  # MJPEG frame with overlays baked in
+    inference_ms: float = 0.0
+    phase: str = "setup"
+    idle_mode: bool = False
 
 
 class PipelineBackend(Protocol):
@@ -47,6 +50,8 @@ class PipelineBackend(Protocol):
     The API layer uses this Protocol exclusively. It never imports
     concrete pipeline classes (DeepStreamPipeline, CustomPipeline).
     """
+
+    channels: dict[int, str]  # channel_id -> source
 
     def start(self) -> None:
         """Boot the inference pipeline (load model, allocate GPU resources)."""

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -392,8 +392,8 @@ class TestWsBroadcaster:
         ws_ch0.send_text = AsyncMock()
 
         broadcaster._clients = [
-            (ws_all, None),       # no filter — receives all
-            (ws_ch0, {0}),        # only channel 0
+            (ws_all, None, None),       # no filter — receives all
+            (ws_ch0, {0}, None),        # only channel 0
         ]
 
         # Broadcast a channel 1 message
@@ -414,7 +414,7 @@ class TestWsBroadcaster:
 
         ws_ch0 = MagicMock()
         ws_ch0.send_text = AsyncMock()
-        broadcaster._clients = [(ws_ch0, {0})]
+        broadcaster._clients = [(ws_ch0, {0}, None)]
 
         msg = {"type": "pipeline_event", "event": "started", "detail": "test"}
         asyncio.run(broadcaster._broadcast(msg))

--- a/backend/tests/test_api_site.py
+++ b/backend/tests/test_api_site.py
@@ -15,9 +15,9 @@ def sites_dir(tmp_path, monkeypatch):
 
 VALID_CONFIG = {
     "site_id": "test_junction",
-    "roi_polygon": [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6], [0.7, 0.8]],
+    "roi_polygon": [[100, 200], [300, 400], [500, 600], [700, 800]],
     "entry_exit_lines": {
-        "north": {"start": [100, 50], "end": [200, 50]},
+        "north": {"label": "741-North", "start": [100, 50], "end": [200, 50]},
     },
 }
 

--- a/backend/tests/test_m2_integration.py
+++ b/backend/tests/test_m2_integration.py
@@ -32,6 +32,10 @@ def test_full_api_lifecycle(client, app):
     resp = client.post("/channel/1/phase", json={"phase": "analytics"})
     assert resp.json()["phase"] == "analytics"
 
+    # Drain phase_changed events from WS queue
+    while not ws_broadcaster._queue.empty():
+        ws_broadcaster._queue.get_nowait()
+
     # -- 4. Update config --
     resp = client.patch("/config", json={"confidence_threshold": 0.6})
     assert resp.status_code == 200
@@ -43,11 +47,13 @@ def test_full_api_lifecycle(client, app):
 
     # MJPEG subscriber got the frame
     assert mjpeg_q.get_nowait() == b"\xff\xd8frame1"
-    # WS broadcaster got frame_data
-    ws_msg = ws_broadcaster._queue.get_nowait()
-    assert ws_msg["type"] == "frame_data"
-    assert ws_msg["channel"] == 0
-    assert ws_msg["frame"] == 1
+    # WS broadcaster got frame_data (may also get stats_update)
+    ws_msgs = []
+    while not ws_broadcaster._queue.empty():
+        ws_msgs.append(ws_broadcaster._queue.get_nowait())
+    frame_msg = next(m for m in ws_msgs if m["type"] == "frame_data")
+    assert frame_msg["channel"] == 0
+    assert frame_msg["frame"] == 1
 
     # -- 6. Simulate alert emission → AlertStore + WS --
     backend.emit_alert({
@@ -132,8 +138,8 @@ def test_site_config_round_trip(client, monkeypatch, tmp_path):
         "site_id": "741_73",
         "roi_polygon": [[0.1, 0.1], [0.9, 0.1], [0.9, 0.9], [0.1, 0.9]],
         "entry_exit_lines": {
-            "north": {"start": [100, 50], "end": [200, 50]},
-            "south": {"start": [100, 350], "end": [200, 350]},
+            "north": {"label": "741-North", "start": [100, 50], "end": [200, 50]},
+            "south": {"label": "741-South", "start": [100, 350], "end": [200, 350]},
         },
     }
 

--- a/backend/tests/test_m3_phase0.py
+++ b/backend/tests/test_m3_phase0.py
@@ -1,0 +1,409 @@
+"""Tests for M3 Phase 0: Backend prerequisites for React UI."""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.api.websocket import WsBroadcaster
+from backend.pipeline.protocol import Detection, FrameResult
+
+
+# -- Fixtures --
+
+TRANSIT_ALERT = {
+    "track_id": 10,
+    "label": "car",
+    "entry_arm": "north",
+    "entry_label": "741-North",
+    "exit_arm": "south",
+    "exit_label": "741-South",
+    "method": "confirmed",
+    "was_stagnant": False,
+    "first_seen_frame": 100,
+    "last_seen_frame": 400,
+    "duration_frames": 300,
+    "trajectory": [(100, 200), (150, 250), (200, 300)],
+    "per_frame_data": [
+        {"frame": 100, "bbox": (10, 20, 30, 40), "centroid": (25, 40),
+         "confidence": 0.9, "timestamp_ms": 3333},
+        {"frame": 200, "bbox": (50, 60, 30, 40), "centroid": (65, 80),
+         "confidence": 0.85, "timestamp_ms": 6666},
+    ],
+}
+
+STAGNANT_ALERT = {
+    "track_id": 20,
+    "label": "truck",
+    "position": (450, 320),
+    "stationary_duration_frames": 4500,
+    "first_seen_frame": 0,
+    "last_seen_frame": 4500,
+}
+
+
+@pytest.fixture
+def started_client(client):
+    """Client with pipeline started and one channel added."""
+    client.post("/pipeline/start")
+    client.post("/channel/add", json={"source": "/data/video.mp4"})
+    return client
+
+
+@pytest.fixture
+def seeded_store(app):
+    """AlertStore with alerts on two channels."""
+    store = app.state.alert_store
+    store.add_transit_alert(TRANSIT_ALERT, channel=0)
+    store.add_stagnant_alert(STAGNANT_ALERT, channel=0)
+    store.add_transit_alert({**TRANSIT_ALERT, "track_id": 30}, channel=1)
+    return store
+
+
+# -- GET /channels --
+
+class TestGetChannels:
+    def test_no_pipeline(self, client):
+        resp = client.get("/channels")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["pipeline_started"] is False
+        assert data["channels"] == []
+
+    def test_one_channel(self, started_client, app):
+        resp = started_client.get("/channels")
+        data = resp.json()
+        assert data["pipeline_started"] is True
+        assert len(data["channels"]) == 1
+        ch = data["channels"][0]
+        assert ch["channel_id"] == 0
+        assert ch["source"] == "/data/video.mp4"
+        assert ch["phase"] == "setup"
+        assert ch["alert_count"] == 0
+
+    def test_two_channels_different_phases(self, started_client, app):
+        started_client.post("/channel/add", json={"source": "/data/b.mp4"})
+        started_client.post("/channel/0/phase", json={"phase": "analytics"})
+        # Seed an alert on channel 0
+        app.state.alert_store.add_transit_alert(TRANSIT_ALERT, channel=0)
+
+        resp = started_client.get("/channels")
+        channels = resp.json()["channels"]
+        assert len(channels) == 2
+        ch0 = next(c for c in channels if c["channel_id"] == 0)
+        ch1 = next(c for c in channels if c["channel_id"] == 1)
+        assert ch0["phase"] == "analytics"
+        assert ch0["alert_count"] == 1
+        assert ch1["phase"] == "setup"
+        assert ch1["alert_count"] == 0
+
+
+# -- Channel filter on GET /alerts --
+
+class TestAlertChannelFilter:
+    def test_filter_by_channel(self, client, seeded_store):
+        resp = client.get("/alerts?channel=0")
+        alerts = resp.json()
+        assert len(alerts) == 2
+        assert all(a["channel"] == 0 for a in alerts)
+
+    def test_filter_channel_1(self, client, seeded_store):
+        resp = client.get("/alerts?channel=1")
+        alerts = resp.json()
+        assert len(alerts) == 1
+        assert alerts[0]["channel"] == 1
+
+    def test_no_filter_returns_all(self, client, seeded_store):
+        resp = client.get("/alerts?limit=200")
+        assert len(resp.json()) == 3
+
+    def test_combined_channel_and_type(self, client, seeded_store):
+        resp = client.get("/alerts?channel=0&type=transit_alert")
+        alerts = resp.json()
+        assert len(alerts) == 1
+        assert alerts[0]["type"] == "transit_alert"
+        assert alerts[0]["channel"] == 0
+
+    def test_empty_channel(self, client, seeded_store):
+        resp = client.get("/alerts?channel=99")
+        assert resp.json() == []
+
+
+# -- WebSocket types filter --
+
+class TestWsTypesFilter:
+    def test_type_filter_allows_matching(self):
+        broadcaster = WsBroadcaster()
+        ws = MagicMock()
+        ws.send_text = AsyncMock()
+        broadcaster._clients = [(ws, None, {"transit_alert"})]
+
+        msg = {"type": "transit_alert", "channel": 0, "alert_id": "abc"}
+        asyncio.run(broadcaster._broadcast(msg))
+        ws.send_text.assert_called_once()
+
+    def test_type_filter_blocks_non_matching(self):
+        broadcaster = WsBroadcaster()
+        ws = MagicMock()
+        ws.send_text = AsyncMock()
+        broadcaster._clients = [(ws, None, {"transit_alert"})]
+
+        msg = {"type": "frame_data", "channel": 0, "frame": 1}
+        asyncio.run(broadcaster._broadcast(msg))
+        ws.send_text.assert_not_called()
+
+    def test_no_type_filter_receives_all(self):
+        broadcaster = WsBroadcaster()
+        ws = MagicMock()
+        ws.send_text = AsyncMock()
+        broadcaster._clients = [(ws, None, None)]
+
+        for msg_type in ["frame_data", "transit_alert", "pipeline_event"]:
+            msg = {"type": msg_type}
+            asyncio.run(broadcaster._broadcast(msg))
+        assert ws.send_text.call_count == 3
+
+    def test_combined_channel_and_type_filter(self):
+        broadcaster = WsBroadcaster()
+        ws = MagicMock()
+        ws.send_text = AsyncMock()
+        # Only channel 0 + only transit_alert
+        broadcaster._clients = [(ws, {0}, {"transit_alert"})]
+
+        # Channel 0, transit_alert — should pass
+        asyncio.run(broadcaster._broadcast(
+            {"type": "transit_alert", "channel": 0}
+        ))
+        assert ws.send_text.call_count == 1
+
+        # Channel 1, transit_alert — blocked by channel filter
+        asyncio.run(broadcaster._broadcast(
+            {"type": "transit_alert", "channel": 1}
+        ))
+        assert ws.send_text.call_count == 1
+
+        # Channel 0, frame_data — blocked by type filter
+        asyncio.run(broadcaster._broadcast(
+            {"type": "frame_data", "channel": 0}
+        ))
+        assert ws.send_text.call_count == 1
+
+    def test_ws_endpoint_parses_types_param(self, client):
+        with client.websocket_connect("/ws?types=transit_alert,stagnant_alert"):
+            pass
+
+
+# -- phase_changed WS event --
+
+class TestPhaseChangedEvent:
+    def test_phase_change_emits_event(self, started_client, app):
+        ws = app.state.ws
+        # Drain queue
+        while not ws._queue.empty():
+            ws._queue.get_nowait()
+
+        started_client.post("/channel/0/phase", json={"phase": "analytics"})
+        msg = ws._queue.get_nowait()
+        assert msg["type"] == "phase_changed"
+        assert msg["channel"] == 0
+        assert msg["phase"] == "analytics"
+        assert msg["previous_phase"] == "setup"
+
+    def test_phase_change_review(self, started_client, app):
+        ws = app.state.ws
+        started_client.post("/channel/0/phase", json={"phase": "analytics"})
+        while not ws._queue.empty():
+            ws._queue.get_nowait()
+
+        started_client.post("/channel/0/phase", json={"phase": "review"})
+        msg = ws._queue.get_nowait()
+        assert msg["type"] == "phase_changed"
+        assert msg["previous_phase"] == "analytics"
+        assert msg["phase"] == "review"
+
+
+# -- stats_update WS message --
+
+class TestStatsUpdate:
+    def test_stats_emitted_after_1_second(self, app):
+        ws = app.state.ws
+        # Drain
+        while not ws._queue.empty():
+            ws._queue.get_nowait()
+
+        # Force the last emit to be >1s ago
+        ws._stats_last_emit[0] = time.monotonic() - 2.0
+        ws._stats_frame_count[0] = 0
+        ws._stats_inference_ms_sum[0] = 0.0
+
+        result = FrameResult(
+            channel_id=0, frame_number=100, timestamp_ms=3333,
+            detections=[
+                Detection(track_id=1, class_name="car",
+                          bbox=(10, 20, 30, 40), confidence=0.9,
+                          centroid=(25, 40)),
+            ],
+            annotated_jpeg=b"\xff\xd8test",
+            inference_ms=5.2, phase="analytics", idle_mode=False,
+        )
+        ws.on_frame(result)
+
+        # Should have frame_data + stats_update
+        messages = []
+        while not ws._queue.empty():
+            messages.append(ws._queue.get_nowait())
+        types = [m["type"] for m in messages]
+        assert "frame_data" in types
+        assert "stats_update" in types
+
+        stats = next(m for m in messages if m["type"] == "stats_update")
+        assert stats["channel"] == 0
+        assert stats["active_tracks"] == 1
+        assert stats["phase"] == "analytics"
+        assert stats["idle_mode"] is False
+        assert "fps" in stats
+        assert "inference_ms" in stats
+
+    def test_stats_not_emitted_before_1_second(self, app):
+        ws = app.state.ws
+        while not ws._queue.empty():
+            ws._queue.get_nowait()
+
+        # Set last emit to now
+        ws._stats_last_emit[0] = time.monotonic()
+        ws._stats_frame_count[0] = 0
+        ws._stats_inference_ms_sum[0] = 0.0
+
+        result = FrameResult(
+            channel_id=0, frame_number=1, timestamp_ms=33,
+            detections=[], annotated_jpeg=b"\xff\xd8test",
+            inference_ms=3.0, phase="setup", idle_mode=False,
+        )
+        ws.on_frame(result)
+
+        messages = []
+        while not ws._queue.empty():
+            messages.append(ws._queue.get_nowait())
+        types = [m["type"] for m in messages]
+        assert "stats_update" not in types
+        assert "frame_data" in types
+
+
+# -- timestamp_ms in per_frame_data --
+
+class TestTimestampMsInPerFrameData:
+    def test_transit_alert_includes_timestamp_ms(self, app):
+        store = app.state.alert_store
+        alert_id = store.add_transit_alert(TRANSIT_ALERT, channel=0)
+        full = store.get_alert(alert_id)
+        for entry in full["per_frame_data"]:
+            assert "timestamp_ms" in entry
+        assert full["per_frame_data"][0]["timestamp_ms"] == 3333
+        assert full["per_frame_data"][1]["timestamp_ms"] == 6666
+
+    def test_timestamp_ms_defaults_to_zero(self, app):
+        store = app.state.alert_store
+        alert_no_ts = {
+            **TRANSIT_ALERT,
+            "per_frame_data": [
+                {"frame": 1, "bbox": (0, 0, 10, 10), "centroid": (5, 5),
+                 "confidence": 0.8},
+            ],
+        }
+        alert_id = store.add_transit_alert(alert_no_ts, channel=0)
+        full = store.get_alert(alert_id)
+        assert full["per_frame_data"][0]["timestamp_ms"] == 0
+
+
+# -- SiteConfigRequest Pydantic model --
+
+class TestSiteConfigValidation:
+    @pytest.fixture(autouse=True)
+    def _redirect_sites(self, tmp_path, monkeypatch):
+        import backend.config.site_config as sc
+        monkeypatch.setattr(sc, "SITES_DIR", tmp_path)
+
+    def test_valid_config(self, client):
+        resp = client.post("/site/config", json={
+            "site_id": "junction_a",
+            "roi_polygon": [[100, 200], [300, 400], [500, 600]],
+            "entry_exit_lines": {
+                "north": {"label": "741-North", "start": [100, 50], "end": [200, 50]},
+            },
+        })
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "saved"}
+
+    def test_missing_site_id(self, client):
+        resp = client.post("/site/config", json={
+            "roi_polygon": [[0, 0], [1, 1], [2, 2]],
+        })
+        assert resp.status_code == 422
+
+    def test_too_few_vertices(self, client):
+        resp = client.post("/site/config", json={
+            "site_id": "bad",
+            "roi_polygon": [[0, 0], [1, 1]],
+        })
+        assert resp.status_code == 422
+
+    def test_empty_polygon(self, client):
+        resp = client.post("/site/config", json={
+            "site_id": "bad",
+            "roi_polygon": [],
+        })
+        assert resp.status_code == 422
+
+    def test_no_entry_exit_lines(self, client):
+        resp = client.post("/site/config", json={
+            "site_id": "minimal",
+            "roi_polygon": [[0, 0], [1, 1], [2, 2]],
+        })
+        assert resp.status_code == 200
+
+    def test_invalid_entry_exit_line(self, client):
+        resp = client.post("/site/config", json={
+            "site_id": "bad",
+            "roi_polygon": [[0, 0], [1, 1], [2, 2]],
+            "entry_exit_lines": {
+                "north": {"start": [100, 50]},  # missing label and end
+            },
+        })
+        assert resp.status_code == 422
+
+
+# -- CORS --
+
+class TestCors:
+    def test_cors_headers_present(self, client):
+        resp = client.options(
+            "/channels",
+            headers={
+                "Origin": "http://localhost:5173",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert resp.headers.get("access-control-allow-origin") == "http://localhost:5173"
+
+    def test_cors_rejects_other_origin(self, client):
+        resp = client.options(
+            "/channels",
+            headers={
+                "Origin": "http://evil.com",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert resp.headers.get("access-control-allow-origin") != "http://evil.com"
+
+
+# -- AlertStore.count_by_channel --
+
+class TestCountByChannel:
+    def test_count_empty(self, app):
+        assert app.state.alert_store.count_by_channel(0) == 0
+
+    def test_count_with_alerts(self, app, seeded_store):
+        assert seeded_store.count_by_channel(0) == 2
+        assert seeded_store.count_by_channel(1) == 1
+        assert seeded_store.count_by_channel(99) == 0


### PR DESCRIPTION
## Summary
- Add CORS middleware for `localhost:5173` (Vite dev server)
- Add `GET /channels` endpoint returning channel list with phase and alert count
- Add `channel` query param to `GET /alerts` for per-channel filtering
- Add WebSocket `types` query param for server-side message type filtering
- Emit `phase_changed` WS event on successful phase transitions
- Emit `stats_update` WS message every 1s per channel (fps, active_tracks, inference_ms, phase, idle_mode)
- Add `timestamp_ms` (video PTS) to `per_frame_data` entries in AlertStore
- Replace raw dict on `POST /site/config` with validated `SiteConfigRequest` Pydantic model
- Add `channels` attribute to `PipelineBackend` Protocol

Closes #29

## Test plan
- [x] 29 new tests in `test_m3_phase0.py`
- [x] All 259 tests passing (was 237)
- [x] Existing M2 integration test updated for new WS events