### PR TITLE
M3 Phase 1.5: UI mockups — design approved

### DIFF
--- a/frontend/mockups/alert-card.html
+++ b/frontend/mockups/alert-card.html
@@ -11,11 +11,15 @@
       theme: {
         extend: {
           colors: {
-            background: '#0f1117',
-            surface: '#1a1d23',
-            border: '#2a2d35',
-            'text-primary': '#e1e1e1',
-            'text-secondary': '#9ca3af',
+            background: '#09090b',
+            surface: '#18181b',
+            elevated: '#27272a',
+            border: '#27272a',
+            'border-strong': '#3f3f46',
+            'text-primary': '#fafafa',
+            'text-secondary': '#a1a1aa',
+            'text-muted': '#71717a',
+            accent: '#6366f1',
             'transit-blue': '#60a5fa',
             'stagnant-amber': '#fbbf24',
             'active-green': '#4ade80',
@@ -33,268 +37,219 @@
 
   <h1 class="text-xl font-bold mb-6">Alert Card — Component Variants</h1>
 
-  <div class="max-w-[340px] space-y-8">
+  <div class="max-w-[300px] space-y-8">
 
-    <!-- SECTION: Transit Cards -->
+    <!-- Transit Cards -->
     <div>
-      <h2 class="text-sm text-text-secondary uppercase tracking-wider mb-3">Transit Alert (Blue)</h2>
+      <h2 class="text-sm text-text-muted uppercase tracking-wider mb-3">Transit Alert (Blue) — 64x64 thumbnail</h2>
       <div class="bg-surface rounded-xl overflow-hidden border border-border">
 
-        <!-- Default state -->
-        <div class="px-3 py-2.5 border-b border-border/50 hover:bg-background/50 transition-colors cursor-pointer">
+        <!-- Default (read-only, Analytics phase) -->
+        <div class="px-3 py-2.5 border-b border-border/50 cursor-default">
           <div class="flex gap-3">
-            <div class="w-12 h-12 rounded-lg bg-background flex-shrink-0 overflow-hidden">
-              <div class="w-full h-full bg-gradient-to-br from-gray-600 to-gray-700 flex items-center justify-center">
-                <span class="text-[8px] text-text-secondary">car</span>
+            <div class="w-16 h-16 rounded-lg bg-background flex-shrink-0 overflow-hidden">
+              <div class="w-full h-full bg-gradient-to-br from-zinc-600 to-zinc-700 flex items-center justify-center">
+                <svg class="w-6 h-6 text-text-muted/40" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14"/></svg>
               </div>
             </div>
             <div class="flex-1 min-w-0">
               <div class="flex items-center gap-2 mb-0.5">
                 <span class="w-1.5 h-1.5 rounded-full bg-transit-blue"></span>
-                <span class="text-xs font-medium text-transit-blue">N → S</span>
-                <span class="text-[10px] text-text-secondary ml-auto">2s ago</span>
+                <span class="text-xs font-medium text-transit-blue">N &#x2192; S</span>
+                <span class="text-[10px] text-text-muted ml-auto">2s ago</span>
               </div>
-              <div class="flex items-center gap-2 text-xs text-text-secondary">
-                <span>car #142</span>
-                <span>·</span>
-                <span>3.4s</span>
-              </div>
+              <div class="text-xs text-text-secondary">car #142 &middot; 3.4s</div>
+              <div class="text-[10px] text-text-muted mt-0.5">confirmed</div>
             </div>
           </div>
+          <span class="text-[10px] text-text-muted mt-1 block">&#x2191; Read-only (Analytics phase)</span>
         </div>
 
-        <!-- Hover state (simulated with bg) -->
+        <!-- Hover (Review phase) -->
         <div class="px-3 py-2.5 border-b border-border/50 bg-background/50 cursor-pointer">
           <div class="flex gap-3">
-            <div class="w-12 h-12 rounded-lg bg-background flex-shrink-0 overflow-hidden">
-              <div class="w-full h-full bg-gradient-to-br from-gray-600 to-gray-700 flex items-center justify-center">
-                <span class="text-[8px] text-text-secondary">truck</span>
+            <div class="w-16 h-16 rounded-lg bg-background flex-shrink-0 overflow-hidden">
+              <div class="w-full h-full bg-gradient-to-br from-zinc-600 to-zinc-700 flex items-center justify-center">
+                <svg class="w-6 h-6 text-text-muted/40" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14"/></svg>
               </div>
             </div>
             <div class="flex-1 min-w-0">
               <div class="flex items-center gap-2 mb-0.5">
                 <span class="w-1.5 h-1.5 rounded-full bg-transit-blue"></span>
-                <span class="text-xs font-medium text-transit-blue">S → N</span>
-                <span class="text-[10px] text-text-secondary ml-auto">15s ago</span>
+                <span class="text-xs font-medium text-transit-blue">S &#x2192; N</span>
+                <span class="text-[10px] text-text-muted ml-auto">12:34:40</span>
               </div>
-              <div class="flex items-center gap-2 text-xs text-text-secondary">
-                <span>truck #138</span>
-                <span>·</span>
-                <span>5.1s</span>
-              </div>
+              <div class="text-xs text-text-secondary">truck #138 &middot; 5.1s</div>
+              <div class="text-[10px] text-text-muted mt-0.5">confirmed</div>
             </div>
           </div>
-          <span class="text-[10px] text-text-secondary mt-1 block">↑ Hover state</span>
+          <span class="text-[10px] text-text-muted mt-1 block">&#x2191; Hover (Review phase)</span>
         </div>
 
-        <!-- Selected state -->
-        <div class="px-3 py-2.5 border-b border-border/50 bg-transit-blue/5 border-l-2 border-l-transit-blue cursor-pointer">
-          <div class="flex gap-3">
-            <div class="w-12 h-12 rounded-lg bg-background flex-shrink-0 overflow-hidden">
-              <div class="w-full h-full bg-gradient-to-br from-gray-500 to-gray-600 flex items-center justify-center">
-                <span class="text-[8px] text-text-secondary">car</span>
+        <!-- Selected + Expanded (accordion) -->
+        <div class="border-b border-border/50 bg-transit-blue/5 border-l-2 border-l-transit-blue">
+          <div class="px-3 py-2.5 cursor-pointer">
+            <div class="flex gap-3">
+              <div class="w-16 h-16 rounded-lg bg-background flex-shrink-0 overflow-hidden">
+                <div class="w-full h-full bg-gradient-to-br from-zinc-500 to-zinc-600 flex items-center justify-center">
+                  <svg class="w-6 h-6 text-text-muted/40" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14"/></svg>
+                  </div>
               </div>
-            </div>
-            <div class="flex-1 min-w-0">
-              <div class="flex items-center gap-2 mb-0.5">
-                <span class="w-1.5 h-1.5 rounded-full bg-transit-blue"></span>
-                <span class="text-xs font-medium text-transit-blue">N → S</span>
-                <span class="text-[10px] text-text-secondary ml-auto">1m ago</span>
-              </div>
-              <div class="flex items-center gap-2 text-xs text-text-secondary">
-                <span>car #131</span>
-                <span>·</span>
-                <span>2.8s</span>
-              </div>
-            </div>
-          </div>
-          <span class="text-[10px] text-text-secondary mt-1 block">↑ Selected state (Review phase)</span>
-        </div>
-
-        <!-- Read-only state (Analytics phase — no click interaction) -->
-        <div class="px-3 py-2.5 cursor-default">
-          <div class="flex gap-3">
-            <div class="w-12 h-12 rounded-lg bg-background flex-shrink-0 overflow-hidden">
-              <div class="w-full h-full bg-gradient-to-br from-gray-600 to-gray-700 flex items-center justify-center">
-                <span class="text-[8px] text-text-secondary">bus</span>
-              </div>
-            </div>
-            <div class="flex-1 min-w-0">
-              <div class="flex items-center gap-2 mb-0.5">
-                <span class="w-1.5 h-1.5 rounded-full bg-transit-blue"></span>
-                <span class="text-xs font-medium text-transit-blue">S → N</span>
-                <span class="text-[10px] text-text-secondary ml-auto">3m ago</span>
-              </div>
-              <div class="flex items-center gap-2 text-xs text-text-secondary">
-                <span>bus #127</span>
-                <span>·</span>
-                <span>6.2s</span>
+              <div class="flex-1 min-w-0">
+                <div class="flex items-center gap-2 mb-0.5">
+                  <span class="w-1.5 h-1.5 rounded-full bg-transit-blue"></span>
+                  <span class="text-xs font-medium text-transit-blue">N &#x2192; S</span>
+                  <span class="text-[10px] text-text-muted ml-auto">12:34:56</span>
+                </div>
+                <div class="text-xs text-text-secondary">car #131 &middot; 2.8s</div>
+                <div class="text-[10px] text-text-muted mt-0.5">confirmed</div>
               </div>
             </div>
           </div>
-          <span class="text-[10px] text-text-secondary mt-1 block">↑ Read-only (Analytics phase)</span>
+          <!-- Accordion content -->
+          <div class="px-3 pb-3 space-y-2">
+            <div class="w-full aspect-square rounded-lg bg-background flex items-center justify-center">
+              <span class="text-text-muted text-xs">Best Photo</span>
+            </div>
+            <div class="grid grid-cols-2 gap-x-3 gap-y-1 text-[11px]">
+              <div><span class="text-text-muted">Direction</span><p>North &#x2192; South</p></div>
+              <div><span class="text-text-muted">Duration</span><p>2.8s</p></div>
+              <div><span class="text-text-muted">Confidence</span><p>0.89</p></div>
+              <div><span class="text-text-muted">Frames</span><p>84</p></div>
+            </div>
+            <div class="flex gap-2">
+              <button class="flex-1 px-2 py-1.5 bg-background border border-border rounded text-[10px] text-text-secondary">Download</button>
+              <button class="flex-1 px-2 py-1.5 bg-transit-blue/10 border border-transit-blue/20 rounded text-[10px] text-transit-blue">Replay</button>
+            </div>
+          </div>
+          <span class="text-[10px] text-text-muted px-3 pb-2 block">&#x2191; Selected + Expanded (Review phase)</span>
         </div>
 
       </div>
     </div>
 
-    <!-- SECTION: Stagnant Cards -->
+    <!-- Stagnant Cards -->
     <div>
-      <h2 class="text-sm text-text-secondary uppercase tracking-wider mb-3">Stagnant Alert (Amber)</h2>
+      <h2 class="text-sm text-text-muted uppercase tracking-wider mb-3">Stagnant Alert (Amber)</h2>
       <div class="bg-surface rounded-xl overflow-hidden border border-border">
 
-        <!-- Default state -->
-        <div class="px-3 py-2.5 border-b border-border/50 hover:bg-background/50 transition-colors cursor-pointer">
+        <!-- Default -->
+        <div class="px-3 py-2.5 border-b border-border/50 cursor-default">
           <div class="flex gap-3">
-            <div class="w-12 h-12 rounded-lg bg-background flex-shrink-0 overflow-hidden">
-              <div class="w-full h-full bg-gradient-to-br from-gray-600 to-gray-700 flex items-center justify-center">
-                <span class="text-[8px] text-text-secondary">car</span>
+            <div class="w-16 h-16 rounded-lg bg-background flex-shrink-0 overflow-hidden">
+              <div class="w-full h-full bg-gradient-to-br from-zinc-600 to-zinc-700 flex items-center justify-center">
+                <svg class="w-6 h-6 text-text-muted/40" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14"/></svg>
               </div>
             </div>
             <div class="flex-1 min-w-0">
               <div class="flex items-center gap-2 mb-0.5">
                 <span class="w-1.5 h-1.5 rounded-full bg-stagnant-amber"></span>
                 <span class="text-xs font-medium text-stagnant-amber">Stagnant</span>
-                <span class="text-[10px] text-text-secondary ml-auto">1m ago</span>
+                <span class="text-[10px] text-text-muted ml-auto">1m ago</span>
               </div>
-              <div class="flex items-center gap-2 text-xs text-text-secondary">
-                <span>car #115</span>
-                <span>·</span>
-                <span>2m 30s</span>
-              </div>
+              <div class="text-xs text-text-secondary">car #115 &middot; 2m 30s</div>
             </div>
           </div>
+          <span class="text-[10px] text-text-muted mt-1 block">&#x2191; Read-only</span>
         </div>
 
-        <!-- Hover state -->
-        <div class="px-3 py-2.5 border-b border-border/50 bg-background/50 cursor-pointer">
-          <div class="flex gap-3">
-            <div class="w-12 h-12 rounded-lg bg-background flex-shrink-0 overflow-hidden">
-              <div class="w-full h-full bg-gradient-to-br from-gray-600 to-gray-700 flex items-center justify-center">
-                <span class="text-[8px] text-text-secondary">truck</span>
+        <!-- Selected + Expanded -->
+        <div class="bg-stagnant-amber/5 border-l-2 border-l-stagnant-amber">
+          <div class="px-3 py-2.5 cursor-pointer">
+            <div class="flex gap-3">
+              <div class="w-16 h-16 rounded-lg bg-background flex-shrink-0 overflow-hidden">
+                <div class="w-full h-full bg-gradient-to-br from-zinc-500 to-zinc-600 flex items-center justify-center">
+                  <svg class="w-6 h-6 text-text-muted/40" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14"/></svg>
+                </div>
               </div>
-            </div>
-            <div class="flex-1 min-w-0">
-              <div class="flex items-center gap-2 mb-0.5">
-                <span class="w-1.5 h-1.5 rounded-full bg-stagnant-amber"></span>
-                <span class="text-xs font-medium text-stagnant-amber">Stagnant</span>
-                <span class="text-[10px] text-text-secondary ml-auto">5m ago</span>
-              </div>
-              <div class="flex items-center gap-2 text-xs text-text-secondary">
-                <span>truck #98</span>
-                <span>·</span>
-                <span>4m 12s</span>
-              </div>
-            </div>
-          </div>
-          <span class="text-[10px] text-text-secondary mt-1 block">↑ Hover state</span>
-        </div>
-
-        <!-- Selected state -->
-        <div class="px-3 py-2.5 bg-stagnant-amber/5 border-l-2 border-l-stagnant-amber cursor-pointer">
-          <div class="flex gap-3">
-            <div class="w-12 h-12 rounded-lg bg-background flex-shrink-0 overflow-hidden">
-              <div class="w-full h-full bg-gradient-to-br from-gray-500 to-gray-600 flex items-center justify-center">
-                <span class="text-[8px] text-text-secondary">van</span>
-              </div>
-            </div>
-            <div class="flex-1 min-w-0">
-              <div class="flex items-center gap-2 mb-0.5">
-                <span class="w-1.5 h-1.5 rounded-full bg-stagnant-amber"></span>
-                <span class="text-xs font-medium text-stagnant-amber">Stagnant</span>
-                <span class="text-[10px] text-text-secondary ml-auto">8m ago</span>
-              </div>
-              <div class="flex items-center gap-2 text-xs text-text-secondary">
-                <span>van #76</span>
-                <span>·</span>
-                <span>6m 45s</span>
+              <div class="flex-1 min-w-0">
+                <div class="flex items-center gap-2 mb-0.5">
+                  <span class="w-1.5 h-1.5 rounded-full bg-stagnant-amber"></span>
+                  <span class="text-xs font-medium text-stagnant-amber">Stagnant</span>
+                  <span class="text-[10px] text-text-muted ml-auto">12:33:15</span>
+                </div>
+                <div class="text-xs text-text-secondary">truck #98 &middot; 4m 12s</div>
               </div>
             </div>
           </div>
-          <span class="text-[10px] text-text-secondary mt-1 block">↑ Selected state (Review phase)</span>
+          <div class="px-3 pb-3 space-y-2">
+            <div class="w-full aspect-square rounded-lg bg-background flex items-center justify-center">
+              <span class="text-text-muted text-xs">Best Photo</span>
+            </div>
+            <div class="grid grid-cols-2 gap-x-3 gap-y-1 text-[11px]">
+              <div><span class="text-text-muted">Position</span><p>(450, 320)</p></div>
+              <div><span class="text-text-muted">Duration</span><p>4m 12s</p></div>
+              <div><span class="text-text-muted">Class</span><p>truck</p></div>
+              <div><span class="text-text-muted">Track ID</span><p>#98</p></div>
+            </div>
+            <button class="w-full px-2 py-1.5 bg-background border border-border rounded text-[10px] text-text-secondary">Download Photo</button>
+          </div>
+          <span class="text-[10px] text-text-muted px-3 pb-2 block">&#x2191; Selected + Expanded (Review phase)</span>
         </div>
 
       </div>
     </div>
 
-    <!-- SECTION: Data Examples -->
+    <!-- Data variety -->
     <div>
-      <h2 class="text-sm text-text-secondary uppercase tracking-wider mb-3">Various Data Examples</h2>
+      <h2 class="text-sm text-text-muted uppercase tracking-wider mb-3">Various Data</h2>
       <div class="bg-surface rounded-xl overflow-hidden border border-border">
-
-        <!-- Short duration, high confidence -->
         <div class="px-3 py-2.5 border-b border-border/50 cursor-pointer">
           <div class="flex gap-3">
-            <div class="w-12 h-12 rounded-lg bg-background flex-shrink-0 overflow-hidden">
-              <div class="w-full h-full bg-gradient-to-br from-gray-600 to-gray-700 flex items-center justify-center">
-                <span class="text-[8px] text-text-secondary">motorcycle</span>
+            <div class="w-16 h-16 rounded-lg bg-background flex-shrink-0 overflow-hidden">
+              <div class="w-full h-full bg-gradient-to-br from-zinc-600 to-zinc-700 flex items-center justify-center">
+                <svg class="w-6 h-6 text-text-muted/40" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14"/></svg>
               </div>
             </div>
             <div class="flex-1 min-w-0">
               <div class="flex items-center gap-2 mb-0.5">
                 <span class="w-1.5 h-1.5 rounded-full bg-transit-blue"></span>
-                <span class="text-xs font-medium text-transit-blue">E → W</span>
-                <span class="text-[10px] text-text-secondary ml-auto">just now</span>
+                <span class="text-xs font-medium text-transit-blue">E &#x2192; W</span>
+                <span class="text-[10px] text-text-muted ml-auto">just now</span>
               </div>
-              <div class="flex items-center gap-2 text-xs text-text-secondary">
-                <span>motorcycle #201</span>
-                <span>·</span>
-                <span>1.2s</span>
-              </div>
+              <div class="text-xs text-text-secondary">motorcycle #201 &middot; 1.2s</div>
+              <div class="text-[10px] text-text-muted mt-0.5">inferred</div>
             </div>
           </div>
         </div>
-
-        <!-- Long duration stagnant -->
         <div class="px-3 py-2.5 border-b border-border/50 cursor-pointer">
           <div class="flex gap-3">
-            <div class="w-12 h-12 rounded-lg bg-background flex-shrink-0 overflow-hidden">
-              <div class="w-full h-full bg-gradient-to-br from-gray-600 to-gray-700 flex items-center justify-center">
-                <span class="text-[8px] text-text-secondary">truck</span>
+            <div class="w-16 h-16 rounded-lg bg-background flex-shrink-0 overflow-hidden">
+              <div class="w-full h-full bg-gradient-to-br from-zinc-600 to-zinc-700 flex items-center justify-center">
+                <svg class="w-6 h-6 text-text-muted/40" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14"/></svg>
               </div>
             </div>
             <div class="flex-1 min-w-0">
               <div class="flex items-center gap-2 mb-0.5">
                 <span class="w-1.5 h-1.5 rounded-full bg-stagnant-amber"></span>
                 <span class="text-xs font-medium text-stagnant-amber">Stagnant</span>
-                <span class="text-[10px] text-text-secondary ml-auto">12m ago</span>
+                <span class="text-[10px] text-text-muted ml-auto">12m ago</span>
               </div>
-              <div class="flex items-center gap-2 text-xs text-text-secondary">
-                <span>truck #45</span>
-                <span>·</span>
-                <span>15m 30s</span>
-              </div>
+              <div class="text-xs text-text-secondary">truck #45 &middot; 15m 30s</div>
             </div>
           </div>
         </div>
-
-        <!-- Long track ID -->
         <div class="px-3 py-2.5 cursor-pointer">
           <div class="flex gap-3">
-            <div class="w-12 h-12 rounded-lg bg-background flex-shrink-0 overflow-hidden">
-              <div class="w-full h-full bg-gradient-to-br from-gray-600 to-gray-700 flex items-center justify-center">
-                <span class="text-[8px] text-text-secondary">car</span>
+            <div class="w-16 h-16 rounded-lg bg-background flex-shrink-0 overflow-hidden">
+              <div class="w-full h-full bg-gradient-to-br from-zinc-600 to-zinc-700 flex items-center justify-center">
+                <svg class="w-6 h-6 text-text-muted/40" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14"/></svg>
               </div>
             </div>
             <div class="flex-1 min-w-0">
               <div class="flex items-center gap-2 mb-0.5">
                 <span class="w-1.5 h-1.5 rounded-full bg-transit-blue"></span>
-                <span class="text-xs font-medium text-transit-blue">W → E</span>
-                <span class="text-[10px] text-text-secondary ml-auto">1h ago</span>
+                <span class="text-xs font-medium text-transit-blue">W &#x2192; E</span>
+                <span class="text-[10px] text-text-muted ml-auto">1h ago</span>
               </div>
-              <div class="flex items-center gap-2 text-xs text-text-secondary">
-                <span>car #1847</span>
-                <span>·</span>
-                <span>4.7s</span>
-              </div>
+              <div class="text-xs text-text-secondary">car #1847 &middot; 4.7s</div>
+              <div class="text-[10px] text-text-muted mt-0.5">confirmed</div>
             </div>
           </div>
         </div>
-
       </div>
     </div>
 
   </div>
-
 </body>
 </html>

--- a/frontend/mockups/channel-analytics.html
+++ b/frontend/mockups/channel-analytics.html
@@ -11,11 +11,16 @@
       theme: {
         extend: {
           colors: {
-            background: '#0f1117',
-            surface: '#1a1d23',
-            border: '#2a2d35',
-            'text-primary': '#e1e1e1',
-            'text-secondary': '#9ca3af',
+            background: '#09090b',
+            surface: '#18181b',
+            elevated: '#27272a',
+            border: '#27272a',
+            'border-strong': '#3f3f46',
+            'text-primary': '#fafafa',
+            'text-secondary': '#a1a1aa',
+            'text-muted': '#71717a',
+            accent: '#6366f1',
+            'accent-hover': '#818cf8',
             'transit-blue': '#60a5fa',
             'stagnant-amber': '#fbbf24',
             'active-green': '#4ade80',
@@ -31,317 +36,204 @@
 </head>
 <body class="bg-background text-text-primary min-h-screen flex flex-col">
 
-  <!-- Control Bar (top) -->
+  <!-- Control Bar -->
   <div class="bg-surface border-b border-border px-4 py-2.5 flex items-center justify-between shrink-0">
     <div class="flex items-center gap-4">
-      <a href="home.html" class="text-text-secondary hover:text-text-primary transition-colors text-sm flex items-center gap-1.5">
+      <a href="home.html" class="text-text-muted hover:text-text-primary transition-colors text-sm flex items-center gap-1.5">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
         Home
       </a>
       <div class="h-4 w-px bg-border"></div>
       <span class="text-sm font-semibold">Channel 0</span>
-      <span class="text-text-secondary text-xs truncate max-w-[200px]">/data/lytle_south.mp4</span>
+      <span class="text-text-muted text-xs truncate max-w-[200px]">/data/lytle_south.mp4</span>
     </div>
 
+    <!-- Phase Indicator (acts as navigation) -->
     <div class="flex items-center gap-1 bg-background rounded-lg p-0.5">
-      <button class="px-3 py-1.5 text-xs font-medium rounded-md text-text-secondary hover:text-text-primary transition-colors">Setup</button>
+      <button class="px-3 py-1.5 text-xs font-medium rounded-md text-text-muted hover:text-text-primary transition-colors">Setup</button>
       <button class="px-3 py-1.5 text-xs font-medium rounded-md bg-transit-blue/10 text-transit-blue">Analytics</button>
-      <button class="px-3 py-1.5 text-xs font-medium rounded-md text-text-secondary hover:text-text-primary transition-colors">Review</button>
+      <button class="px-3 py-1.5 text-xs font-medium rounded-md text-text-muted hover:text-text-primary transition-colors">Review</button>
     </div>
 
     <div class="flex items-center gap-3">
+      <!-- Confidence Slider (PRD F-77) -->
+      <div class="flex items-center gap-2">
+        <span class="text-xs text-text-muted">Conf:</span>
+        <input type="range" min="0" max="100" value="50"
+          class="w-16 h-1 bg-elevated rounded-full appearance-none [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:bg-accent [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:cursor-pointer">
+        <span class="text-xs text-text-secondary w-6">0.50</span>
+      </div>
+      <div class="h-4 w-px bg-border"></div>
       <span class="flex items-center gap-1.5 text-xs text-active-green">
         <span class="w-1.5 h-1.5 rounded-full bg-active-green animate-pulse"></span>
         Live
       </span>
-      <button class="px-3 py-1.5 bg-active-green/10 text-active-green border border-active-green/20 rounded-lg text-xs font-medium hover:bg-active-green/20 transition-colors">
-        Stop → Review
-      </button>
     </div>
   </div>
 
   <!-- Main Content -->
   <div class="flex flex-1 min-h-0">
 
-    <!-- Video Panel (left) -->
+    <!-- Video Panel -->
     <div class="flex-1 flex flex-col min-w-0">
       <div class="flex-1 relative bg-black flex items-center justify-center">
         <div class="relative" style="width: 960px; height: 540px; background: #111;">
-          <div class="absolute inset-0 bg-gradient-to-br from-gray-900 to-gray-800 flex items-center justify-center">
-            <span class="text-text-secondary text-sm">MJPEG Live Feed — Annotations Baked In</span>
+          <div class="absolute inset-0 bg-gradient-to-br from-zinc-900 to-zinc-800 flex items-center justify-center">
+            <span class="text-text-muted text-sm">MJPEG Live Feed — Annotations Baked In</span>
           </div>
 
-          <!-- Simulated bounding boxes and tracks baked into frame -->
+          <!-- Simulated bounding boxes -->
           <svg class="absolute inset-0 w-full h-full" viewBox="0 0 960 540">
-            <!-- Vehicle 1 -->
             <rect x="300" y="200" width="90" height="60" fill="none" stroke="#4ade80" stroke-width="2" rx="2"/>
             <text x="300" y="195" fill="#4ade80" font-size="11" font-weight="bold">car #142</text>
-
-            <!-- Vehicle 2 -->
             <rect x="550" y="320" width="110" height="70" fill="none" stroke="#4ade80" stroke-width="2" rx="2"/>
             <text x="550" y="315" fill="#4ade80" font-size="11" font-weight="bold">truck #138</text>
-
-            <!-- Vehicle 3 (stagnant — amber) -->
             <rect x="680" y="180" width="85" height="55" fill="none" stroke="#fbbf24" stroke-width="2" rx="2"/>
-            <text x="680" y="175" fill="#fbbf24" font-size="11" font-weight="bold">car #115 ⏸</text>
+            <text x="680" y="175" fill="#fbbf24" font-size="11" font-weight="bold">car #115 &#x23F8;</text>
           </svg>
         </div>
       </div>
 
-      <!-- Stats Bar -->
+      <!-- Stats Bar (UX-E: warning colors) -->
       <div class="bg-surface border-t border-border px-4 py-2 flex items-center gap-6 text-xs shrink-0">
-        <span class="text-text-secondary">FPS: <span class="text-active-green font-medium">29.8</span></span>
-        <span class="text-text-secondary">Tracks: <span class="text-text-primary font-medium">7</span></span>
-        <span class="text-text-secondary">Inference: <span class="text-text-primary font-medium">4.2ms</span></span>
-        <span class="text-text-secondary">Phase: <span class="text-transit-blue font-medium">Analytics</span></span>
-        <div class="ml-auto flex items-center gap-2">
-          <span class="text-transit-blue">47 transit</span>
-          <span class="text-text-secondary">·</span>
-          <span class="text-stagnant-amber">3 stagnant</span>
-        </div>
+        <span class="text-text-muted">FPS: <span class="text-active-green font-medium">29.8</span></span>
+        <span class="text-text-muted">Tracks: <span class="text-text-primary font-medium">7</span></span>
+        <span class="text-text-muted">Inference: <span class="text-text-primary font-medium">4.2ms</span></span>
+        <span class="text-text-muted">Phase: <span class="text-transit-blue font-medium">Analytics</span></span>
+        <div class="ml-auto text-text-secondary">50 alerts</div>
       </div>
     </div>
 
-    <!-- Alert Feed Sidebar (right) -->
-    <div class="w-[320px] bg-surface border-l border-border flex flex-col shrink-0">
+    <!-- Alert Feed Sidebar (300px per PRD F-87, read-only during Analytics) -->
+    <div class="w-[300px] bg-surface border-l border-border flex flex-col shrink-0">
       <!-- Filter Bar -->
-      <div class="px-4 py-3 border-b border-border flex items-center justify-between">
+      <div class="px-3 py-2.5 border-b border-border flex items-center justify-between">
         <div class="flex items-center gap-1 bg-background rounded-lg p-0.5">
-          <button class="px-2.5 py-1 text-xs font-medium rounded-md bg-text-primary/10 text-text-primary">All (50)</button>
-          <button class="px-2.5 py-1 text-xs font-medium rounded-md text-text-secondary hover:text-text-primary">Transit</button>
-          <button class="px-2.5 py-1 text-xs font-medium rounded-md text-text-secondary hover:text-text-primary">Stagnant</button>
+          <button class="px-2 py-1 text-xs font-medium rounded-md bg-text-primary/10 text-text-primary">All (50)</button>
+          <button class="px-2 py-1 text-xs font-medium rounded-md text-text-muted hover:text-text-primary">Transit</button>
+          <button class="px-2 py-1 text-xs font-medium rounded-md text-text-muted hover:text-text-primary">Stagnant</button>
         </div>
-        <!-- New alerts badge -->
-        <span class="px-2 py-0.5 bg-transit-blue/10 text-transit-blue text-xs rounded-full font-medium animate-pulse">
-          3 new ↓
+        <span class="px-2 py-0.5 bg-transit-blue/10 text-transit-blue text-[10px] rounded-full font-medium animate-pulse">
+          3 new &#x2193;
         </span>
       </div>
 
-      <!-- Alert Cards -->
+      <!-- Alert Cards (read-only, 64x64 thumbnails) -->
       <div class="flex-1 overflow-y-auto">
 
         <!-- Transit alert card -->
-        <div class="px-3 py-2.5 border-b border-border/50 hover:bg-background/50 transition-colors cursor-default">
+        <div class="px-3 py-2.5 border-b border-border/50 cursor-default">
           <div class="flex gap-3">
-            <!-- Thumbnail -->
-            <div class="w-12 h-12 rounded-lg bg-background flex-shrink-0 flex items-center justify-center overflow-hidden">
-              <div class="w-full h-full bg-gradient-to-br from-gray-700 to-gray-800 flex items-center justify-center">
-                <span class="text-[8px] text-text-secondary">car</span>
+            <div class="w-16 h-16 rounded-lg bg-background flex-shrink-0 overflow-hidden">
+              <div class="w-full h-full bg-gradient-to-br from-zinc-700 to-zinc-800 flex items-center justify-center">
+                <svg class="w-6 h-6 text-text-muted/40" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14"/></svg>
               </div>
             </div>
             <div class="flex-1 min-w-0">
               <div class="flex items-center gap-2 mb-0.5">
                 <span class="w-1.5 h-1.5 rounded-full bg-transit-blue"></span>
-                <span class="text-xs font-medium text-transit-blue">N → S</span>
-                <span class="text-[10px] text-text-secondary ml-auto">2s ago</span>
+                <span class="text-xs font-medium text-transit-blue">N &#x2192; S</span>
+                <span class="text-[10px] text-text-muted ml-auto">2s ago</span>
               </div>
-              <div class="flex items-center gap-2 text-xs text-text-secondary">
-                <span>car #142</span>
-                <span>·</span>
-                <span>3.4s</span>
-              </div>
+              <div class="text-xs text-text-secondary">car #142 &middot; 3.4s</div>
+              <div class="text-[10px] text-text-muted mt-0.5">confirmed</div>
             </div>
           </div>
         </div>
 
         <!-- Transit alert card 2 -->
-        <div class="px-3 py-2.5 border-b border-border/50 hover:bg-background/50 transition-colors cursor-default">
+        <div class="px-3 py-2.5 border-b border-border/50 cursor-default">
           <div class="flex gap-3">
-            <div class="w-12 h-12 rounded-lg bg-background flex-shrink-0 flex items-center justify-center">
-              <div class="w-full h-full bg-gradient-to-br from-gray-700 to-gray-800 flex items-center justify-center">
-                <span class="text-[8px] text-text-secondary">truck</span>
+            <div class="w-16 h-16 rounded-lg bg-background flex-shrink-0 overflow-hidden">
+              <div class="w-full h-full bg-gradient-to-br from-zinc-700 to-zinc-800 flex items-center justify-center">
+                <svg class="w-6 h-6 text-text-muted/40" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14"/></svg>
               </div>
             </div>
             <div class="flex-1 min-w-0">
               <div class="flex items-center gap-2 mb-0.5">
                 <span class="w-1.5 h-1.5 rounded-full bg-transit-blue"></span>
-                <span class="text-xs font-medium text-transit-blue">S → N</span>
-                <span class="text-[10px] text-text-secondary ml-auto">15s ago</span>
+                <span class="text-xs font-medium text-transit-blue">S &#x2192; N</span>
+                <span class="text-[10px] text-text-muted ml-auto">15s ago</span>
               </div>
-              <div class="flex items-center gap-2 text-xs text-text-secondary">
-                <span>truck #138</span>
-                <span>·</span>
-                <span>5.1s</span>
-              </div>
+              <div class="text-xs text-text-secondary">truck #138 &middot; 5.1s</div>
+              <div class="text-[10px] text-text-muted mt-0.5">confirmed</div>
             </div>
           </div>
         </div>
 
         <!-- Stagnant alert card -->
-        <div class="px-3 py-2.5 border-b border-border/50 hover:bg-background/50 transition-colors cursor-default">
+        <div class="px-3 py-2.5 border-b border-border/50 cursor-default">
           <div class="flex gap-3">
-            <div class="w-12 h-12 rounded-lg bg-background flex-shrink-0 flex items-center justify-center">
-              <div class="w-full h-full bg-gradient-to-br from-gray-700 to-gray-800 flex items-center justify-center">
-                <span class="text-[8px] text-text-secondary">car</span>
+            <div class="w-16 h-16 rounded-lg bg-background flex-shrink-0 overflow-hidden">
+              <div class="w-full h-full bg-gradient-to-br from-zinc-700 to-zinc-800 flex items-center justify-center">
+                <svg class="w-6 h-6 text-text-muted/40" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14"/></svg>
               </div>
             </div>
             <div class="flex-1 min-w-0">
               <div class="flex items-center gap-2 mb-0.5">
                 <span class="w-1.5 h-1.5 rounded-full bg-stagnant-amber"></span>
                 <span class="text-xs font-medium text-stagnant-amber">Stagnant</span>
-                <span class="text-[10px] text-text-secondary ml-auto">1m ago</span>
+                <span class="text-[10px] text-text-muted ml-auto">1m ago</span>
               </div>
-              <div class="flex items-center gap-2 text-xs text-text-secondary">
-                <span>car #115</span>
-                <span>·</span>
-                <span>2m 30s</span>
-              </div>
+              <div class="text-xs text-text-secondary">car #115 &middot; 2m 30s</div>
             </div>
           </div>
         </div>
 
-        <!-- More transit alerts -->
-        <div class="px-3 py-2.5 border-b border-border/50 hover:bg-background/50 transition-colors cursor-default">
+        <!-- More transit cards -->
+        <div class="px-3 py-2.5 border-b border-border/50 cursor-default">
           <div class="flex gap-3">
-            <div class="w-12 h-12 rounded-lg bg-background flex-shrink-0 flex items-center justify-center">
-              <div class="w-full h-full bg-gradient-to-br from-gray-700 to-gray-800 flex items-center justify-center">
-                <span class="text-[8px] text-text-secondary">car</span>
+            <div class="w-16 h-16 rounded-lg bg-background flex-shrink-0 overflow-hidden">
+              <div class="w-full h-full bg-gradient-to-br from-zinc-700 to-zinc-800 flex items-center justify-center">
+                <svg class="w-6 h-6 text-text-muted/40" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14"/></svg>
               </div>
             </div>
             <div class="flex-1 min-w-0">
               <div class="flex items-center gap-2 mb-0.5">
                 <span class="w-1.5 h-1.5 rounded-full bg-transit-blue"></span>
-                <span class="text-xs font-medium text-transit-blue">N → S</span>
-                <span class="text-[10px] text-text-secondary ml-auto">2m ago</span>
+                <span class="text-xs font-medium text-transit-blue">N &#x2192; S</span>
+                <span class="text-[10px] text-text-muted ml-auto">2m ago</span>
               </div>
-              <div class="flex items-center gap-2 text-xs text-text-secondary">
-                <span>car #131</span>
-                <span>·</span>
-                <span>2.8s</span>
-              </div>
+              <div class="text-xs text-text-secondary">car #131 &middot; 2.8s</div>
+              <div class="text-[10px] text-text-muted mt-0.5">confirmed</div>
             </div>
           </div>
         </div>
 
-        <div class="px-3 py-2.5 border-b border-border/50 hover:bg-background/50 transition-colors cursor-default">
+        <div class="px-3 py-2.5 border-b border-border/50 cursor-default">
           <div class="flex gap-3">
-            <div class="w-12 h-12 rounded-lg bg-background flex-shrink-0 flex items-center justify-center">
-              <div class="w-full h-full bg-gradient-to-br from-gray-700 to-gray-800 flex items-center justify-center">
-                <span class="text-[8px] text-text-secondary">bus</span>
+            <div class="w-16 h-16 rounded-lg bg-background flex-shrink-0 overflow-hidden">
+              <div class="w-full h-full bg-gradient-to-br from-zinc-700 to-zinc-800 flex items-center justify-center">
+                <svg class="w-6 h-6 text-text-muted/40" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14"/></svg>
               </div>
             </div>
             <div class="flex-1 min-w-0">
               <div class="flex items-center gap-2 mb-0.5">
                 <span class="w-1.5 h-1.5 rounded-full bg-transit-blue"></span>
-                <span class="text-xs font-medium text-transit-blue">S → N</span>
-                <span class="text-[10px] text-text-secondary ml-auto">3m ago</span>
+                <span class="text-xs font-medium text-transit-blue">S &#x2192; N</span>
+                <span class="text-[10px] text-text-muted ml-auto">3m ago</span>
               </div>
-              <div class="flex items-center gap-2 text-xs text-text-secondary">
-                <span>bus #127</span>
-                <span>·</span>
-                <span>6.2s</span>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="px-3 py-2.5 border-b border-border/50 hover:bg-background/50 transition-colors cursor-default">
-          <div class="flex gap-3">
-            <div class="w-12 h-12 rounded-lg bg-background flex-shrink-0 flex items-center justify-center">
-              <div class="w-full h-full bg-gradient-to-br from-gray-700 to-gray-800 flex items-center justify-center">
-                <span class="text-[8px] text-text-secondary">car</span>
-              </div>
-            </div>
-            <div class="flex-1 min-w-0">
-              <div class="flex items-center gap-2 mb-0.5">
-                <span class="w-1.5 h-1.5 rounded-full bg-transit-blue"></span>
-                <span class="text-xs font-medium text-transit-blue">N → S</span>
-                <span class="text-[10px] text-text-secondary ml-auto">4m ago</span>
-              </div>
-              <div class="flex items-center gap-2 text-xs text-text-secondary">
-                <span>car #119</span>
-                <span>·</span>
-                <span>3.1s</span>
-              </div>
+              <div class="text-xs text-text-secondary">bus #127 &middot; 6.2s</div>
+              <div class="text-[10px] text-text-muted mt-0.5">inferred</div>
             </div>
           </div>
         </div>
 
         <!-- Stagnant -->
-        <div class="px-3 py-2.5 border-b border-border/50 hover:bg-background/50 transition-colors cursor-default">
+        <div class="px-3 py-2.5 border-b border-border/50 cursor-default">
           <div class="flex gap-3">
-            <div class="w-12 h-12 rounded-lg bg-background flex-shrink-0 flex items-center justify-center">
-              <div class="w-full h-full bg-gradient-to-br from-gray-700 to-gray-800 flex items-center justify-center">
-                <span class="text-[8px] text-text-secondary">truck</span>
+            <div class="w-16 h-16 rounded-lg bg-background flex-shrink-0 overflow-hidden">
+              <div class="w-full h-full bg-gradient-to-br from-zinc-700 to-zinc-800 flex items-center justify-center">
+                <svg class="w-6 h-6 text-text-muted/40" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14"/></svg>
               </div>
             </div>
             <div class="flex-1 min-w-0">
               <div class="flex items-center gap-2 mb-0.5">
                 <span class="w-1.5 h-1.5 rounded-full bg-stagnant-amber"></span>
                 <span class="text-xs font-medium text-stagnant-amber">Stagnant</span>
-                <span class="text-[10px] text-text-secondary ml-auto">5m ago</span>
+                <span class="text-[10px] text-text-muted ml-auto">5m ago</span>
               </div>
-              <div class="flex items-center gap-2 text-xs text-text-secondary">
-                <span>truck #98</span>
-                <span>·</span>
-                <span>4m 12s</span>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="px-3 py-2.5 border-b border-border/50 hover:bg-background/50 transition-colors cursor-default">
-          <div class="flex gap-3">
-            <div class="w-12 h-12 rounded-lg bg-background flex-shrink-0 flex items-center justify-center">
-              <div class="w-full h-full bg-gradient-to-br from-gray-700 to-gray-800 flex items-center justify-center">
-                <span class="text-[8px] text-text-secondary">car</span>
-              </div>
-            </div>
-            <div class="flex-1 min-w-0">
-              <div class="flex items-center gap-2 mb-0.5">
-                <span class="w-1.5 h-1.5 rounded-full bg-transit-blue"></span>
-                <span class="text-xs font-medium text-transit-blue">S → N</span>
-                <span class="text-[10px] text-text-secondary ml-auto">6m ago</span>
-              </div>
-              <div class="flex items-center gap-2 text-xs text-text-secondary">
-                <span>car #112</span>
-                <span>·</span>
-                <span>2.5s</span>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="px-3 py-2.5 border-b border-border/50 hover:bg-background/50 transition-colors cursor-default">
-          <div class="flex gap-3">
-            <div class="w-12 h-12 rounded-lg bg-background flex-shrink-0 flex items-center justify-center">
-              <div class="w-full h-full bg-gradient-to-br from-gray-700 to-gray-800 flex items-center justify-center">
-                <span class="text-[8px] text-text-secondary">car</span>
-              </div>
-            </div>
-            <div class="flex-1 min-w-0">
-              <div class="flex items-center gap-2 mb-0.5">
-                <span class="w-1.5 h-1.5 rounded-full bg-transit-blue"></span>
-                <span class="text-xs font-medium text-transit-blue">N → S</span>
-                <span class="text-[10px] text-text-secondary ml-auto">7m ago</span>
-              </div>
-              <div class="flex items-center gap-2 text-xs text-text-secondary">
-                <span>car #105</span>
-                <span>·</span>
-                <span>4.0s</span>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="px-3 py-2.5 border-b border-border/50 hover:bg-background/50 transition-colors cursor-default">
-          <div class="flex gap-3">
-            <div class="w-12 h-12 rounded-lg bg-background flex-shrink-0 flex items-center justify-center">
-              <div class="w-full h-full bg-gradient-to-br from-gray-700 to-gray-800 flex items-center justify-center">
-                <span class="text-[8px] text-text-secondary">car</span>
-              </div>
-            </div>
-            <div class="flex-1 min-w-0">
-              <div class="flex items-center gap-2 mb-0.5">
-                <span class="w-1.5 h-1.5 rounded-full bg-transit-blue"></span>
-                <span class="text-xs font-medium text-transit-blue">S → N</span>
-                <span class="text-[10px] text-text-secondary ml-auto">9m ago</span>
-              </div>
-              <div class="flex items-center gap-2 text-xs text-text-secondary">
-                <span>car #99</span>
-                <span>·</span>
-                <span>3.6s</span>
-              </div>
+              <div class="text-xs text-text-secondary">truck #98 &middot; 4m 12s</div>
             </div>
           </div>
         </div>
@@ -349,6 +241,27 @@
       </div>
     </div>
 
+  </div>
+
+  <!-- Stats bar warning states (UX-E) -->
+  <div class="p-6">
+    <div class="border-t border-border pt-6 mt-2">
+      <p class="text-text-muted text-xs uppercase tracking-wider mb-4">UX-E: Stats bar warning states</p>
+      <div class="space-y-2 max-w-3xl">
+        <div class="bg-surface border border-border rounded-lg px-4 py-2 flex items-center gap-6 text-xs">
+          <span class="text-text-muted">FPS: <span class="text-stagnant-amber font-medium">12.4</span></span>
+          <span class="text-text-muted">Tracks: <span class="text-text-primary font-medium">23</span></span>
+          <span class="text-text-muted">Inference: <span class="text-stagnant-amber font-medium">24.1ms</span></span>
+          <span class="text-text-muted ml-4">&#x2191; Amber: FPS &lt; 15 or inference &gt; 20ms</span>
+        </div>
+        <div class="bg-surface border border-border rounded-lg px-4 py-2 flex items-center gap-6 text-xs">
+          <span class="text-text-muted">FPS: <span class="text-error-red font-medium">3.1</span></span>
+          <span class="text-text-muted">Tracks: <span class="text-text-primary font-medium">31</span></span>
+          <span class="text-text-muted">Inference: <span class="text-error-red font-medium">48.7ms</span></span>
+          <span class="text-text-muted ml-4">&#x2191; Red: FPS &lt; 5 or inference &gt; 40ms</span>
+        </div>
+      </div>
+    </div>
   </div>
 
 </body>

--- a/frontend/mockups/channel-review.html
+++ b/frontend/mockups/channel-review.html
@@ -11,11 +11,15 @@
       theme: {
         extend: {
           colors: {
-            background: '#0f1117',
-            surface: '#1a1d23',
-            border: '#2a2d35',
-            'text-primary': '#e1e1e1',
-            'text-secondary': '#9ca3af',
+            background: '#09090b',
+            surface: '#18181b',
+            elevated: '#27272a',
+            border: '#27272a',
+            'border-strong': '#3f3f46',
+            'text-primary': '#fafafa',
+            'text-secondary': '#a1a1aa',
+            'text-muted': '#71717a',
+            accent: '#6366f1',
             'transit-blue': '#60a5fa',
             'stagnant-amber': '#fbbf24',
             'active-green': '#4ade80',
@@ -27,6 +31,7 @@
   </script>
   <style>
     body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+    .state-label { border-top: 1px solid #27272a; padding-top: 2rem; margin-top: 2.5rem; }
   </style>
 </head>
 <body class="bg-background text-text-primary min-h-screen flex flex-col">
@@ -34,273 +39,228 @@
   <!-- Control Bar -->
   <div class="bg-surface border-b border-border px-4 py-2.5 flex items-center justify-between shrink-0">
     <div class="flex items-center gap-4">
-      <a href="home.html" class="text-text-secondary hover:text-text-primary transition-colors text-sm flex items-center gap-1.5">
+      <a href="home.html" class="text-text-muted hover:text-text-primary transition-colors text-sm flex items-center gap-1.5">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
         Home
       </a>
       <div class="h-4 w-px bg-border"></div>
       <span class="text-sm font-semibold">Channel 0</span>
-      <span class="text-text-secondary text-xs truncate max-w-[200px]">/data/lytle_south.mp4</span>
+      <span class="text-text-muted text-xs truncate max-w-[200px]">/data/lytle_south.mp4</span>
     </div>
 
     <div class="flex items-center gap-1 bg-background rounded-lg p-0.5">
-      <button class="px-3 py-1.5 text-xs font-medium rounded-md text-text-secondary hover:text-text-primary transition-colors">Setup</button>
-      <button class="px-3 py-1.5 text-xs font-medium rounded-md text-text-secondary hover:text-text-primary transition-colors">Analytics</button>
+      <button class="px-3 py-1.5 text-xs font-medium rounded-md text-text-muted" disabled>Setup</button>
+      <button class="px-3 py-1.5 text-xs font-medium rounded-md text-text-muted" disabled>Analytics</button>
       <button class="px-3 py-1.5 text-xs font-medium rounded-md bg-active-green/10 text-active-green">Review</button>
     </div>
 
     <div class="flex items-center gap-3">
-      <span class="text-text-secondary text-xs">47 transit · 3 stagnant</span>
+      <span class="text-text-secondary text-xs">50 alerts</span>
     </div>
   </div>
 
   <!-- Main Content -->
   <div class="flex flex-1 min-h-0">
 
-    <!-- Replay Panel (left) -->
+    <!-- Replay Panel -->
     <div class="flex-1 flex flex-col min-w-0">
-      <!-- Replay area -->
       <div class="flex-1 relative bg-black flex items-center justify-center">
         <div class="relative" style="width: 960px; height: 540px; background: #111;">
-          <!-- Replay clip or frame -->
-          <div class="absolute inset-0 bg-gradient-to-br from-gray-900 to-gray-800 flex items-center justify-center">
-            <span class="text-text-secondary text-sm">Transit Replay — car #142</span>
+          <div class="absolute inset-0 bg-gradient-to-br from-zinc-900 to-zinc-800 flex items-center justify-center">
+            <span class="text-text-muted text-sm">Transit Replay &#x2014; car #142</span>
           </div>
 
-          <!-- Replay bbox overlay -->
+          <!-- Replay canvas overlay: bbox + trajectory -->
           <svg class="absolute inset-0 w-full h-full" viewBox="0 0 960 540">
-            <!-- Active bbox on current frame -->
             <rect x="380" y="240" width="95" height="65" fill="none" stroke="#60a5fa" stroke-width="2.5" rx="2"/>
-            <!-- Trajectory trail -->
-            <polyline
-              points="200,120 250,160 310,200 380,240 420,275"
-              fill="none"
-              stroke="#60a5fa"
-              stroke-width="1.5"
-              stroke-dasharray="4,3"
-              opacity="0.6"
-            />
-            <!-- Entry point -->
-            <circle cx="200" cy="120" r="4" fill="#4ade80" opacity="0.8"/>
-            <text x="210" y="118" fill="#4ade80" font-size="10" opacity="0.8">N entry</text>
+            <polyline points="200,120 250,160 310,200 380,240 420,275" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="4,3" opacity="0.5"/>
+            <circle cx="200" cy="120" r="4" fill="#4ade80" opacity="0.7"/>
+            <rect x="208" y="110" width="50" height="16" rx="3" fill="rgba(0,0,0,0.7)"/>
+            <text x="233" y="122" text-anchor="middle" fill="#4ade80" font-size="10">N entry</text>
           </svg>
         </div>
       </div>
 
-      <!-- Replay controls -->
-      <div class="bg-surface border-t border-border px-4 py-2.5 flex items-center gap-4 shrink-0">
-        <button class="text-text-secondary hover:text-text-primary transition-colors">
-          <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>
-        </button>
-        <!-- Progress bar -->
-        <div class="flex-1 h-1 bg-background rounded-full overflow-hidden">
-          <div class="h-full bg-transit-blue rounded-full" style="width: 45%"></div>
-        </div>
-        <span class="text-xs text-text-secondary">1.5s / 3.4s</span>
-        <button class="text-xs text-text-secondary hover:text-text-primary transition-colors">Loop</button>
-      </div>
+      <!-- No stats bar in Review phase -->
     </div>
 
-    <!-- Right Panel — Alert Feed + Detail -->
-    <div class="w-[360px] bg-surface border-l border-border flex flex-col shrink-0">
+    <!-- Alert Feed Sidebar (300px, clickable in Review) -->
+    <div class="w-[300px] bg-surface border-l border-border flex flex-col shrink-0">
       <!-- Filter Bar -->
-      <div class="px-4 py-3 border-b border-border flex items-center gap-2">
+      <div class="px-3 py-2.5 border-b border-border flex items-center gap-2">
         <div class="flex items-center gap-1 bg-background rounded-lg p-0.5">
-          <button class="px-2.5 py-1 text-xs font-medium rounded-md bg-text-primary/10 text-text-primary">All (50)</button>
-          <button class="px-2.5 py-1 text-xs font-medium rounded-md text-text-secondary hover:text-text-primary">Transit</button>
-          <button class="px-2.5 py-1 text-xs font-medium rounded-md text-text-secondary hover:text-text-primary">Stagnant</button>
+          <button class="px-2 py-1 text-xs font-medium rounded-md bg-text-primary/10 text-text-primary">All (50)</button>
+          <button class="px-2 py-1 text-xs font-medium rounded-md text-text-muted hover:text-text-primary">Transit</button>
+          <button class="px-2 py-1 text-xs font-medium rounded-md text-text-muted hover:text-text-primary">Stagnant</button>
         </div>
       </div>
 
-      <!-- Alert Cards (scrollable) -->
+      <!-- Alert Cards (scrollable, clickable) -->
       <div class="flex-1 overflow-y-auto">
 
-        <!-- Selected transit alert -->
-        <div class="px-3 py-2.5 border-b border-border/50 bg-transit-blue/5 border-l-2 border-l-transit-blue cursor-pointer">
+        <!-- Selected transit alert (accordion expanded per Design doc 16.3) -->
+        <div class="border-b border-border/50 bg-transit-blue/5 border-l-2 border-l-transit-blue">
+          <!-- Compact card -->
+          <div class="px-3 py-2.5 cursor-pointer">
+            <div class="flex gap-3">
+              <div class="w-16 h-16 rounded-lg bg-background flex-shrink-0 overflow-hidden">
+                <div class="w-full h-full bg-gradient-to-br from-zinc-600 to-zinc-700 flex items-center justify-center">
+                  <svg class="w-6 h-6 text-text-muted/40" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14"/></svg>
+                </div>
+              </div>
+              <div class="flex-1 min-w-0">
+                <div class="flex items-center gap-2 mb-0.5">
+                  <span class="w-1.5 h-1.5 rounded-full bg-transit-blue"></span>
+                  <span class="text-xs font-medium text-transit-blue">N &#x2192; S</span>
+                  <span class="text-[10px] text-text-muted ml-auto">12:34:56</span>
+                </div>
+                <div class="text-xs text-text-secondary">car #142 &middot; 3.4s</div>
+                <div class="text-[10px] text-text-muted mt-0.5">confirmed</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Accordion expanded content (Design doc 16.3) -->
+          <div class="px-3 pb-3 space-y-3">
+            <!-- Full-size best photo -->
+            <div class="w-full aspect-square rounded-lg bg-background overflow-hidden">
+              <div class="w-full h-full bg-gradient-to-br from-zinc-700 to-zinc-800 flex items-center justify-center">
+                <span class="text-text-muted text-xs">Best Photo (full size)</span>
+              </div>
+            </div>
+
+            <!-- Metadata grid -->
+            <div class="grid grid-cols-2 gap-x-4 gap-y-1.5 text-xs">
+              <div><span class="text-text-muted">Track ID</span><p class="text-text-primary">#142</p></div>
+              <div><span class="text-text-muted">Class</span><p class="text-text-primary">car</p></div>
+              <div><span class="text-text-muted">Direction</span><p class="text-text-primary">North &#x2192; South</p></div>
+              <div><span class="text-text-muted">Duration</span><p class="text-text-primary">3.4s</p></div>
+              <div><span class="text-text-muted">Avg Confidence</span><p class="text-text-primary">0.91</p></div>
+              <div><span class="text-text-muted">Max Confidence</span><p class="text-text-primary">0.95</p></div>
+              <div><span class="text-text-muted">Frames Tracked</span><p class="text-text-primary">102</p></div>
+              <div><span class="text-text-muted">Method</span><p class="text-text-primary">confirmed</p></div>
+            </div>
+
+            <!-- Trajectory minimap -->
+            <div class="w-full h-20 bg-background rounded-lg overflow-hidden relative">
+              <svg class="w-full h-full" viewBox="0 0 260 80">
+                <!-- Junction outline -->
+                <rect x="10" y="5" width="240" height="70" fill="none" stroke="#27272a" stroke-width="1" rx="2"/>
+                <!-- Trajectory line -->
+                <polyline points="130,10 125,20 115,35 105,50 100,65" fill="none" stroke="#60a5fa" stroke-width="2"/>
+                <circle cx="130" cy="10" r="3" fill="#4ade80"/>
+                <circle cx="100" cy="65" r="3" fill="#f87171"/>
+              </svg>
+              <span class="absolute bottom-1 right-2 text-[9px] text-text-muted">Trajectory</span>
+            </div>
+
+            <!-- Action buttons -->
+            <div class="flex gap-2">
+              <button class="flex-1 px-3 py-2 bg-background border border-border rounded-lg text-xs text-text-secondary hover:text-text-primary hover:border-border-strong transition-colors flex items-center justify-center gap-1.5">
+                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
+                Download Photo
+              </button>
+              <button class="flex-1 px-3 py-2 bg-transit-blue/10 border border-transit-blue/20 rounded-lg text-xs text-transit-blue hover:bg-transit-blue/20 transition-colors flex items-center justify-center gap-1.5">
+                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+                Replay
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Unselected transit (collapsed) -->
+        <div class="px-3 py-2.5 border-b border-border/50 hover:bg-background/50 transition-colors cursor-pointer">
           <div class="flex gap-3">
-            <div class="w-12 h-12 rounded-lg bg-background flex-shrink-0 overflow-hidden">
-              <div class="w-full h-full bg-gradient-to-br from-gray-600 to-gray-700 flex items-center justify-center">
-                <span class="text-[8px] text-text-secondary">car</span>
+            <div class="w-16 h-16 rounded-lg bg-background flex-shrink-0 overflow-hidden">
+              <div class="w-full h-full bg-gradient-to-br from-zinc-700 to-zinc-800 flex items-center justify-center">
+                <svg class="w-6 h-6 text-text-muted/40" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14"/></svg>
               </div>
             </div>
             <div class="flex-1 min-w-0">
               <div class="flex items-center gap-2 mb-0.5">
                 <span class="w-1.5 h-1.5 rounded-full bg-transit-blue"></span>
-                <span class="text-xs font-medium text-transit-blue">N → S</span>
-                <span class="text-[10px] text-text-secondary ml-auto">12:34:56</span>
+                <span class="text-xs font-medium text-transit-blue">S &#x2192; N</span>
+                <span class="text-[10px] text-text-muted ml-auto">12:34:40</span>
               </div>
-              <div class="flex items-center gap-2 text-xs text-text-secondary">
-                <span>car #142</span>
-                <span>·</span>
-                <span>3.4s</span>
-              </div>
+              <div class="text-xs text-text-secondary">truck #138 &middot; 5.1s</div>
+              <div class="text-[10px] text-text-muted mt-0.5">confirmed</div>
             </div>
           </div>
         </div>
 
-        <!-- Unselected transit -->
+        <!-- Stagnant (collapsed) -->
         <div class="px-3 py-2.5 border-b border-border/50 hover:bg-background/50 transition-colors cursor-pointer">
           <div class="flex gap-3">
-            <div class="w-12 h-12 rounded-lg bg-background flex-shrink-0">
-              <div class="w-full h-full bg-gradient-to-br from-gray-700 to-gray-800 flex items-center justify-center">
-                <span class="text-[8px] text-text-secondary">truck</span>
-              </div>
-            </div>
-            <div class="flex-1 min-w-0">
-              <div class="flex items-center gap-2 mb-0.5">
-                <span class="w-1.5 h-1.5 rounded-full bg-transit-blue"></span>
-                <span class="text-xs font-medium text-transit-blue">S → N</span>
-                <span class="text-[10px] text-text-secondary ml-auto">12:34:40</span>
-              </div>
-              <div class="flex items-center gap-2 text-xs text-text-secondary">
-                <span>truck #138</span>
-                <span>·</span>
-                <span>5.1s</span>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <!-- Stagnant alert -->
-        <div class="px-3 py-2.5 border-b border-border/50 hover:bg-background/50 transition-colors cursor-pointer">
-          <div class="flex gap-3">
-            <div class="w-12 h-12 rounded-lg bg-background flex-shrink-0">
-              <div class="w-full h-full bg-gradient-to-br from-gray-700 to-gray-800 flex items-center justify-center">
-                <span class="text-[8px] text-text-secondary">car</span>
+            <div class="w-16 h-16 rounded-lg bg-background flex-shrink-0 overflow-hidden">
+              <div class="w-full h-full bg-gradient-to-br from-zinc-700 to-zinc-800 flex items-center justify-center">
+                <svg class="w-6 h-6 text-text-muted/40" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14"/></svg>
               </div>
             </div>
             <div class="flex-1 min-w-0">
               <div class="flex items-center gap-2 mb-0.5">
                 <span class="w-1.5 h-1.5 rounded-full bg-stagnant-amber"></span>
                 <span class="text-xs font-medium text-stagnant-amber">Stagnant</span>
-                <span class="text-[10px] text-text-secondary ml-auto">12:33:15</span>
+                <span class="text-[10px] text-text-muted ml-auto">12:33:15</span>
               </div>
-              <div class="flex items-center gap-2 text-xs text-text-secondary">
-                <span>car #115</span>
-                <span>·</span>
-                <span>2m 30s</span>
-              </div>
+              <div class="text-xs text-text-secondary">car #115 &middot; 2m 30s</div>
             </div>
           </div>
         </div>
 
-        <!-- More cards... -->
+        <!-- More collapsed cards -->
         <div class="px-3 py-2.5 border-b border-border/50 hover:bg-background/50 transition-colors cursor-pointer">
           <div class="flex gap-3">
-            <div class="w-12 h-12 rounded-lg bg-background flex-shrink-0">
-              <div class="w-full h-full bg-gradient-to-br from-gray-700 to-gray-800 flex items-center justify-center">
-                <span class="text-[8px] text-text-secondary">car</span>
+            <div class="w-16 h-16 rounded-lg bg-background flex-shrink-0 overflow-hidden">
+              <div class="w-full h-full bg-gradient-to-br from-zinc-700 to-zinc-800 flex items-center justify-center">
+                <svg class="w-6 h-6 text-text-muted/40" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14"/></svg>
               </div>
             </div>
             <div class="flex-1 min-w-0">
               <div class="flex items-center gap-2 mb-0.5">
                 <span class="w-1.5 h-1.5 rounded-full bg-transit-blue"></span>
-                <span class="text-xs font-medium text-transit-blue">N → S</span>
-                <span class="text-[10px] text-text-secondary ml-auto">12:32:10</span>
+                <span class="text-xs font-medium text-transit-blue">N &#x2192; S</span>
+                <span class="text-[10px] text-text-muted ml-auto">12:32:10</span>
               </div>
-              <div class="flex items-center gap-2 text-xs text-text-secondary">
-                <span>car #131</span>
-                <span>·</span>
-                <span>2.8s</span>
-              </div>
+              <div class="text-xs text-text-secondary">car #131 &middot; 2.8s</div>
+              <div class="text-[10px] text-text-muted mt-0.5">confirmed</div>
             </div>
           </div>
         </div>
 
-        <div class="px-3 py-2.5 border-b border-border/50 hover:bg-background/50 transition-colors cursor-pointer">
-          <div class="flex gap-3">
-            <div class="w-12 h-12 rounded-lg bg-background flex-shrink-0">
-              <div class="w-full h-full bg-gradient-to-br from-gray-700 to-gray-800 flex items-center justify-center">
-                <span class="text-[8px] text-text-secondary">bus</span>
-              </div>
-            </div>
-            <div class="flex-1 min-w-0">
-              <div class="flex items-center gap-2 mb-0.5">
-                <span class="w-1.5 h-1.5 rounded-full bg-transit-blue"></span>
-                <span class="text-xs font-medium text-transit-blue">S → N</span>
-                <span class="text-[10px] text-text-secondary ml-auto">12:30:55</span>
-              </div>
-              <div class="flex items-center gap-2 text-xs text-text-secondary">
-                <span>bus #127</span>
-                <span>·</span>
-                <span>6.2s</span>
-              </div>
-            </div>
-          </div>
-        </div>
-
-      </div>
-
-      <!-- Alert Detail Panel (bottom) -->
-      <div class="border-t border-border p-4">
-        <div class="flex items-center justify-between mb-3">
-          <h3 class="text-sm font-semibold">Alert Details</h3>
-          <span class="px-2 py-0.5 bg-transit-blue/10 text-transit-blue text-xs rounded-full">Transit</span>
-        </div>
-
-        <div class="grid grid-cols-2 gap-2 text-xs mb-3">
-          <div>
-            <span class="text-text-secondary">Track ID</span>
-            <p class="font-medium">#142</p>
-          </div>
-          <div>
-            <span class="text-text-secondary">Class</span>
-            <p class="font-medium">car</p>
-          </div>
-          <div>
-            <span class="text-text-secondary">Direction</span>
-            <p class="font-medium">North → South</p>
-          </div>
-          <div>
-            <span class="text-text-secondary">Duration</span>
-            <p class="font-medium">3.4s</p>
-          </div>
-          <div>
-            <span class="text-text-secondary">Confidence</span>
-            <p class="font-medium">0.91</p>
-          </div>
-          <div>
-            <span class="text-text-secondary">Method</span>
-            <p class="font-medium">confirmed</p>
-          </div>
-        </div>
-
-        <button class="w-full px-3 py-2 bg-background border border-border rounded-lg text-xs text-text-secondary hover:text-text-primary hover:border-text-secondary transition-colors flex items-center justify-center gap-2">
-          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
-          Download Best Photo
-        </button>
       </div>
     </div>
 
   </div>
 
-  <!-- ==================== ALTERNATE STATE: Spinner (clip extracting) ==================== -->
-  <div class="border-t border-border mt-8 pt-6 px-6">
-    <p class="text-text-secondary text-xs uppercase tracking-wider mb-4">Alternate State: Clip Extracting</p>
-    <div class="bg-black rounded-xl overflow-hidden" style="height: 300px;">
-      <div class="w-full h-full flex flex-col items-center justify-center gap-3">
-        <svg class="w-8 h-8 text-transit-blue animate-spin" fill="none" viewBox="0 0 24 24">
-          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-        </svg>
-        <span class="text-text-secondary text-sm">Extracting replay clip...</span>
-        <span class="text-text-secondary text-xs">This may take a few seconds</span>
+  <!-- Alternate states -->
+  <div class="p-6">
+    <!-- Spinner state -->
+    <div class="state-label">
+      <p class="text-text-muted text-xs uppercase tracking-wider mb-4">Alternate: Clip Extracting (spinner)</p>
+      <div class="bg-black rounded-xl overflow-hidden" style="height: 240px; max-width: 800px;">
+        <div class="w-full h-full flex flex-col items-center justify-center gap-3">
+          <svg class="w-8 h-8 text-accent animate-spin" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+          </svg>
+          <span class="text-text-secondary text-sm">Extracting replay clip...</span>
+        </div>
       </div>
     </div>
-  </div>
 
-  <!-- ==================== ALTERNATE STATE: Stagnant alert view ==================== -->
-  <div class="border-t border-border mt-8 pt-6 px-6 pb-8">
-    <p class="text-text-secondary text-xs uppercase tracking-wider mb-4">Alternate State: Stagnant Alert (Static Frame + BBox)</p>
-    <div class="bg-black rounded-xl overflow-hidden" style="height: 300px;">
-      <div class="w-full h-full relative flex items-center justify-center">
-        <div class="absolute inset-0 bg-gradient-to-br from-gray-900 to-gray-800"></div>
-        <svg class="absolute inset-0 w-full h-full" viewBox="0 0 960 300">
-          <!-- Stagnant vehicle bbox -->
-          <rect x="410" y="100" width="100" height="65" fill="none" stroke="#fbbf24" stroke-width="2.5" rx="2"/>
-          <text x="410" y="95" fill="#fbbf24" font-size="11" font-weight="bold">car #115 — Stagnant 2m 30s</text>
-        </svg>
-        <span class="text-text-secondary text-xs absolute bottom-3 left-3">Static frame at best-photo timestamp</span>
+    <!-- Stagnant view -->
+    <div class="state-label">
+      <p class="text-text-muted text-xs uppercase tracking-wider mb-4">Alternate: Stagnant Alert (static frame + bbox)</p>
+      <div class="bg-black rounded-xl overflow-hidden" style="height: 240px; max-width: 800px;">
+        <div class="w-full h-full relative">
+          <div class="absolute inset-0 bg-gradient-to-br from-zinc-900 to-zinc-800"></div>
+          <svg class="absolute inset-0 w-full h-full" viewBox="0 0 800 240">
+            <rect x="340" y="80" width="100" height="65" fill="none" stroke="#fbbf24" stroke-width="2.5" rx="2"/>
+            <rect x="340" y="60" width="180" height="16" rx="3" fill="rgba(0,0,0,0.7)"/>
+            <text x="430" y="72" text-anchor="middle" fill="#fbbf24" font-size="11" font-weight="bold">car #115 &#x2014; Stagnant 2m 30s</text>
+          </svg>
+          <span class="text-text-muted text-xs absolute bottom-3 left-3">Static frame at best-photo timestamp</span>
+        </div>
       </div>
     </div>
   </div>

--- a/frontend/mockups/channel-setup.html
+++ b/frontend/mockups/channel-setup.html
@@ -11,11 +11,16 @@
       theme: {
         extend: {
           colors: {
-            background: '#0f1117',
-            surface: '#1a1d23',
-            border: '#2a2d35',
-            'text-primary': '#e1e1e1',
-            'text-secondary': '#9ca3af',
+            background: '#09090b',
+            surface: '#18181b',
+            elevated: '#27272a',
+            border: '#27272a',
+            'border-strong': '#3f3f46',
+            'text-primary': '#fafafa',
+            'text-secondary': '#a1a1aa',
+            'text-muted': '#71717a',
+            accent: '#6366f1',
+            'accent-hover': '#818cf8',
             'transit-blue': '#60a5fa',
             'stagnant-amber': '#fbbf24',
             'active-green': '#4ade80',
@@ -27,27 +32,28 @@
   </script>
   <style>
     body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+    .state-label { border-top: 1px solid #27272a; padding-top: 2rem; margin-top: 2.5rem; }
   </style>
 </head>
 <body class="bg-background text-text-primary min-h-screen flex flex-col">
 
-  <!-- Control Bar (top) -->
+  <!-- Control Bar -->
   <div class="bg-surface border-b border-border px-4 py-2.5 flex items-center justify-between shrink-0">
     <div class="flex items-center gap-4">
-      <a href="home.html" class="text-text-secondary hover:text-text-primary transition-colors text-sm flex items-center gap-1.5">
+      <a href="home.html" class="text-text-muted hover:text-text-primary transition-colors text-sm flex items-center gap-1.5">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
         Home
       </a>
       <div class="h-4 w-px bg-border"></div>
       <span class="text-sm font-semibold">Channel 0</span>
-      <span class="text-text-secondary text-xs truncate max-w-[200px]">/data/lytle_south.mp4</span>
+      <span class="text-text-muted text-xs truncate max-w-[200px]">/data/lytle_south.mp4</span>
     </div>
 
     <!-- Phase Indicator -->
     <div class="flex items-center gap-1 bg-background rounded-lg p-0.5">
       <button class="px-3 py-1.5 text-xs font-medium rounded-md bg-stagnant-amber/10 text-stagnant-amber">Setup</button>
-      <button class="px-3 py-1.5 text-xs font-medium rounded-md text-text-secondary hover:text-text-primary transition-colors">Analytics</button>
-      <button class="px-3 py-1.5 text-xs font-medium rounded-md text-text-secondary hover:text-text-primary transition-colors">Review</button>
+      <button class="px-3 py-1.5 text-xs font-medium rounded-md text-text-muted" disabled>Analytics</button>
+      <button class="px-3 py-1.5 text-xs font-medium rounded-md text-text-muted" disabled>Review</button>
     </div>
 
     <div class="flex items-center gap-3">
@@ -61,75 +67,79 @@
   <!-- Main Content -->
   <div class="flex flex-1 min-h-0">
 
-    <!-- Video Panel (left) -->
+    <!-- Video Panel -->
     <div class="flex-1 flex flex-col min-w-0">
-      <!-- Video + Canvas Overlay -->
       <div class="flex-1 relative bg-black flex items-center justify-center">
-        <!-- MJPEG placeholder with mock ROI and lines drawn -->
         <div class="relative" style="width: 960px; height: 540px; background: #111;">
-          <!-- Simulated video frame (dark placeholder) -->
-          <div class="absolute inset-0 bg-gradient-to-br from-gray-900 to-gray-800 flex items-center justify-center">
-            <span class="text-text-secondary text-sm">MJPEG Live Feed — 1920x1080</span>
+          <div class="absolute inset-0 bg-gradient-to-br from-zinc-900 to-zinc-800 flex items-center justify-center">
+            <span class="text-text-muted text-sm">MJPEG Live Feed — 1920x1080</span>
           </div>
 
-          <!-- Mock ROI polygon overlay -->
+          <!-- Canvas overlay: ROI polygon + entry/exit lines -->
           <svg class="absolute inset-0 w-full h-full" viewBox="0 0 960 540">
-            <!-- ROI polygon -->
+            <!-- ROI polygon (closed, solid stroke, 15% fill) -->
             <polygon
               points="120,80 840,80 880,460 80,460"
-              fill="rgba(96,165,250,0.08)"
-              stroke="#60a5fa"
+              fill="rgba(99,102,241,0.12)"
+              stroke="#6366f1"
               stroke-width="2"
-              stroke-dasharray="6,3"
             />
-            <!-- ROI vertices -->
-            <circle cx="120" cy="80" r="5" fill="#60a5fa" stroke="#0f1117" stroke-width="2"/>
-            <circle cx="840" cy="80" r="5" fill="#60a5fa" stroke="#0f1117" stroke-width="2"/>
-            <circle cx="880" cy="460" r="5" fill="#60a5fa" stroke="#0f1117" stroke-width="2"/>
-            <circle cx="80" cy="460" r="5" fill="#60a5fa" stroke="#0f1117" stroke-width="2"/>
+            <!-- ROI vertices (white, 6px; first vertex green, 8px) -->
+            <circle cx="120" cy="80" r="5" fill="#fafafa" stroke="#09090b" stroke-width="2"/>
+            <circle cx="840" cy="80" r="5" fill="#fafafa" stroke="#09090b" stroke-width="2"/>
+            <circle cx="880" cy="460" r="5" fill="#fafafa" stroke="#09090b" stroke-width="2"/>
+            <circle cx="80" cy="460" r="5" fill="#fafafa" stroke="#09090b" stroke-width="2"/>
 
-            <!-- Entry/exit line: North -->
+            <!-- Entry/exit line: North (green, 3px) -->
             <line x1="200" y1="100" x2="760" y2="100" stroke="#4ade80" stroke-width="3"/>
-            <circle cx="200" cy="100" r="4" fill="#4ade80"/>
-            <circle cx="760" cy="100" r="4" fill="#4ade80"/>
-            <text x="480" y="92" text-anchor="middle" fill="#4ade80" font-size="12" font-weight="bold">North</text>
+            <circle cx="200" cy="100" r="5" fill="#fafafa" stroke="#09090b" stroke-width="2"/>
+            <circle cx="760" cy="100" r="5" fill="#fafafa" stroke="#09090b" stroke-width="2"/>
+            <rect x="440" y="78" width="80" height="20" rx="4" fill="rgba(0,0,0,0.7)"/>
+            <text x="480" y="92" text-anchor="middle" fill="#4ade80" font-size="12" font-weight="600">North</text>
 
-            <!-- Entry/exit line: South -->
+            <!-- Entry/exit line: South (amber, 3px) -->
             <line x1="160" y1="440" x2="800" y2="440" stroke="#fbbf24" stroke-width="3"/>
-            <circle cx="160" cy="440" r="4" fill="#fbbf24"/>
-            <circle cx="800" cy="440" r="4" fill="#fbbf24"/>
-            <text x="480" y="432" text-anchor="middle" fill="#fbbf24" font-size="12" font-weight="bold">South</text>
+            <circle cx="160" cy="440" r="5" fill="#fafafa" stroke="#09090b" stroke-width="2"/>
+            <circle cx="800" cy="440" r="5" fill="#fafafa" stroke="#09090b" stroke-width="2"/>
+            <rect x="440" y="418" width="80" height="20" rx="4" fill="rgba(0,0,0,0.7)"/>
+            <text x="480" y="432" text-anchor="middle" fill="#fbbf24" font-size="12" font-weight="600">South</text>
           </svg>
+
+          <!-- Drawing mode cursor tooltip (shown during drawing) -->
+          <div class="absolute top-3 left-3 bg-black/70 text-text-secondary text-xs px-2.5 py-1.5 rounded-md">
+            Click first point or double-click to close &nbsp;·&nbsp; Ctrl+Z to undo
+          </div>
         </div>
       </div>
 
-      <!-- Stats Bar (bottom) -->
-      <div class="bg-surface border-t border-border px-4 py-2 flex items-center gap-6 text-xs shrink-0">
-        <span class="text-text-secondary">FPS: <span class="text-text-primary font-medium">—</span></span>
-        <span class="text-text-secondary">Tracks: <span class="text-text-primary font-medium">—</span></span>
-        <span class="text-text-secondary">Inference: <span class="text-text-primary font-medium">—</span></span>
-        <span class="text-text-secondary">Phase: <span class="text-stagnant-amber font-medium">Setup</span></span>
-      </div>
+      <!-- No stats bar in Setup phase (per PRD) -->
     </div>
 
     <!-- Right Panel — Drawing Tools + Config -->
-    <div class="w-[320px] bg-surface border-l border-border flex flex-col shrink-0">
+    <div class="w-[300px] bg-surface border-l border-border flex flex-col shrink-0">
       <!-- Drawing Tools -->
       <div class="p-4 border-b border-border">
         <h3 class="text-sm font-semibold mb-3">Drawing Tools</h3>
 
         <div class="space-y-2">
-          <!-- ROI tool -->
-          <button class="w-full flex items-center gap-3 px-3 py-2.5 bg-transit-blue/10 border border-transit-blue/30 rounded-lg text-sm text-transit-blue">
+          <!-- ROI tool (active state) -->
+          <button class="w-full flex items-center gap-3 px-3 py-2.5 bg-accent/10 border border-accent/30 rounded-lg text-sm text-accent">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v14a1 1 0 01-1 1H5a1 1 0 01-1-1V5z"/></svg>
             Draw ROI Polygon
-            <span class="ml-auto text-xs text-transit-blue/60">Active</span>
+            <span class="ml-auto text-xs text-accent/60">Active</span>
           </button>
 
           <!-- Entry/Exit Line tool -->
-          <button class="w-full flex items-center gap-3 px-3 py-2.5 bg-background border border-border rounded-lg text-sm text-text-secondary hover:text-text-primary hover:border-text-secondary transition-colors">
+          <button class="w-full flex items-center gap-3 px-3 py-2.5 bg-background border border-border rounded-lg text-sm text-text-secondary hover:text-text-primary hover:border-border-strong transition-colors">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 12h16"/></svg>
             Add Entry/Exit Line
+          </button>
+
+          <!-- Undo (UX-D) -->
+          <button class="w-full flex items-center gap-3 px-3 py-2.5 bg-background border border-border rounded-lg text-sm text-text-secondary hover:text-text-primary hover:border-border-strong transition-colors">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h10a5 5 0 015 5v2M3 10l4-4M3 10l4 4"/></svg>
+            Undo Last Point
+            <span class="ml-auto text-xs text-text-muted">Ctrl+Z</span>
           </button>
 
           <!-- Clear All -->
@@ -149,7 +159,7 @@
               <span class="w-2.5 h-2.5 rounded-full bg-active-green"></span>
               <span class="text-sm">North</span>
             </div>
-            <button class="text-text-secondary hover:text-error-red transition-colors">
+            <button class="text-text-muted hover:text-error-red transition-colors">
               <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
             </button>
           </div>
@@ -158,7 +168,7 @@
               <span class="w-2.5 h-2.5 rounded-full bg-stagnant-amber"></span>
               <span class="text-sm">South</span>
             </div>
-            <button class="text-text-secondary hover:text-error-red transition-colors">
+            <button class="text-text-muted hover:text-error-red transition-colors">
               <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
             </button>
           </div>
@@ -168,48 +178,112 @@
       <!-- Site Config -->
       <div class="p-4 flex-1">
         <h3 class="text-sm font-semibold mb-3">Site Configuration</h3>
-
         <div class="space-y-3">
           <div>
-            <label class="text-xs text-text-secondary block mb-1">Site ID</label>
-            <div class="flex gap-2">
-              <input
-                type="text"
-                value="741_73"
-                class="flex-1 px-3 py-2 bg-background border border-border rounded-lg text-sm text-text-primary focus:outline-none focus:border-transit-blue/50"
-              >
-            </div>
+            <label class="text-xs text-text-muted block mb-1">Site ID</label>
+            <input type="text" value="741_73"
+              class="w-full px-3 py-2 bg-background border border-border rounded-lg text-sm text-text-primary focus:outline-none focus:border-accent/50">
           </div>
-
           <div class="flex gap-2">
-            <button class="flex-1 px-3 py-2 bg-transit-blue text-white rounded-lg text-sm font-medium hover:bg-transit-blue/90 transition-colors">
-              Save Config
+            <button class="flex-1 px-3 py-2 bg-accent text-white rounded-lg text-sm font-medium hover:bg-accent-hover transition-colors">
+              Save
             </button>
             <button class="flex-1 px-3 py-2 bg-background border border-border rounded-lg text-sm text-text-secondary hover:text-text-primary transition-colors">
-              Load Config
+              Load
             </button>
           </div>
-
-          <!-- Saved configs dropdown -->
           <div>
-            <label class="text-xs text-text-secondary block mb-1">Saved Configs</label>
-            <select class="w-full px-3 py-2 bg-background border border-border rounded-lg text-sm text-text-primary focus:outline-none focus:border-transit-blue/50 appearance-none">
+            <label class="text-xs text-text-muted block mb-1">Saved Configs</label>
+            <select class="w-full px-3 py-2 bg-background border border-border rounded-lg text-sm text-text-primary focus:outline-none focus:border-accent/50">
               <option>741_73</option>
               <option>lytle_south</option>
-              <option>test_junction</option>
             </select>
+          </div>
+
+          <!-- Confidence Threshold (PRD F-77) -->
+          <div>
+            <label class="text-xs text-text-muted block mb-1">Confidence Threshold</label>
+            <div class="flex items-center gap-3">
+              <input type="range" min="0" max="100" value="50"
+                class="flex-1 h-1.5 bg-elevated rounded-full appearance-none [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3.5 [&::-webkit-slider-thumb]:h-3.5 [&::-webkit-slider-thumb]:bg-accent [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:cursor-pointer">
+              <span class="text-xs text-text-secondary w-8 text-right">0.50</span>
+            </div>
           </div>
         </div>
       </div>
 
-      <!-- Bottom action -->
-      <div class="p-4 border-t border-border">
+      <!-- Bottom action (UX-A: disabled when no ROI) -->
+      <div class="p-4 border-t border-border space-y-3">
+        <!-- Enabled state (ROI drawn) -->
         <button class="w-full px-4 py-2.5 bg-active-green/10 text-active-green border border-active-green/20 rounded-lg text-sm font-medium hover:bg-active-green/20 transition-colors">
-          Start Analytics →
+          Start Analytics
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- ==================== Disabled button state ==================== -->
+  <div class="p-6">
+    <div class="state-label">
+      <p class="text-text-muted text-xs uppercase tracking-wider mb-4">UX-A: Start Analytics disabled (no ROI drawn)</p>
+      <div class="w-[300px]">
+        <button disabled class="w-full px-4 py-2.5 bg-elevated border border-border rounded-lg text-sm font-medium text-text-muted cursor-not-allowed">
+          Draw ROI to continue
         </button>
       </div>
     </div>
 
+    <!-- ==================== Drawing in progress (rubber band) ==================== -->
+    <div class="state-label">
+      <p class="text-text-muted text-xs uppercase tracking-wider mb-4">Drawing Mode: ROI in progress (3 vertices placed, rubber band to cursor)</p>
+      <div class="relative bg-black rounded-xl overflow-hidden" style="width: 600px; height: 340px;">
+        <div class="absolute inset-0 bg-gradient-to-br from-zinc-900 to-zinc-800"></div>
+        <svg class="absolute inset-0 w-full h-full" viewBox="0 0 600 340">
+          <!-- Placed edges (solid) -->
+          <line x1="100" y1="60" x2="480" y2="50" stroke="#6366f1" stroke-width="2"/>
+          <line x1="480" y1="50" x2="500" y2="270" stroke="#6366f1" stroke-width="2"/>
+          <!-- Rubber band to cursor (solid) -->
+          <line x1="500" y1="270" x2="350" y2="300" stroke="#6366f1" stroke-width="2" opacity="0.6"/>
+          <!-- Closing preview (dashed) -->
+          <line x1="350" y1="300" x2="100" y2="60" stroke="#6366f1" stroke-width="1.5" stroke-dasharray="6,4" opacity="0.4"/>
+          <!-- Vertices -->
+          <circle cx="100" cy="60" r="6" fill="#4ade80" stroke="#09090b" stroke-width="2"/> <!-- First = green -->
+          <circle cx="480" cy="50" r="5" fill="#fafafa" stroke="#09090b" stroke-width="2"/>
+          <circle cx="500" cy="270" r="5" fill="#fafafa" stroke="#09090b" stroke-width="2"/>
+          <!-- Cursor position (crosshair indicator) -->
+          <circle cx="350" cy="300" r="3" fill="#6366f1" opacity="0.5"/>
+        </svg>
+        <div class="absolute top-3 left-3 bg-black/70 text-text-secondary text-xs px-2.5 py-1.5 rounded-md">
+          Click first point or double-click to close &nbsp;·&nbsp; Ctrl+Z to undo &nbsp;·&nbsp; Esc to cancel
+        </div>
+      </div>
+    </div>
+
+    <!-- ==================== Line label input ==================== -->
+    <div class="state-label">
+      <p class="text-text-muted text-xs uppercase tracking-wider mb-4">Drawing Mode: Line placed, label input at midpoint</p>
+      <div class="relative bg-black rounded-xl overflow-hidden" style="width: 600px; height: 200px;">
+        <div class="absolute inset-0 bg-gradient-to-br from-zinc-900 to-zinc-800"></div>
+        <svg class="absolute inset-0 w-full h-full" viewBox="0 0 600 200">
+          <line x1="120" y1="100" x2="480" y2="100" stroke="#4ade80" stroke-width="3"/>
+          <circle cx="120" cy="100" r="5" fill="#fafafa" stroke="#09090b" stroke-width="2"/>
+          <circle cx="480" cy="100" r="5" fill="#fafafa" stroke="#09090b" stroke-width="2"/>
+        </svg>
+        <!-- Label input popover -->
+        <div class="absolute" style="left: 240px; top: 60px;">
+          <div class="bg-surface border border-border-strong rounded-lg shadow-xl p-2 w-[140px]">
+            <input type="text" placeholder="Label..." value="East"
+              class="w-full px-2 py-1.5 bg-background border border-border rounded text-sm text-text-primary focus:outline-none focus:border-accent/50 text-center" autofocus>
+            <div class="flex gap-1 mt-1.5">
+              <button class="flex-1 px-1 py-1 text-[10px] text-text-muted hover:text-text-primary bg-background rounded">N</button>
+              <button class="flex-1 px-1 py-1 text-[10px] text-text-muted hover:text-text-primary bg-background rounded">S</button>
+              <button class="flex-1 px-1 py-1 text-[10px] text-accent bg-accent/10 rounded font-medium">E</button>
+              <button class="flex-1 px-1 py-1 text-[10px] text-text-muted hover:text-text-primary bg-background rounded">W</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 
 </body>

--- a/frontend/mockups/home.html
+++ b/frontend/mockups/home.html
@@ -11,11 +11,16 @@
       theme: {
         extend: {
           colors: {
-            background: '#0f1117',
-            surface: '#1a1d23',
-            border: '#2a2d35',
-            'text-primary': '#e1e1e1',
-            'text-secondary': '#9ca3af',
+            background: '#09090b',
+            surface: '#18181b',
+            elevated: '#27272a',
+            border: '#27272a',
+            'border-strong': '#3f3f46',
+            'text-primary': '#fafafa',
+            'text-secondary': '#a1a1aa',
+            'text-muted': '#71717a',
+            accent: '#6366f1',
+            'accent-hover': '#818cf8',
             'transit-blue': '#60a5fa',
             'stagnant-amber': '#fbbf24',
             'active-green': '#4ade80',
@@ -27,7 +32,10 @@
   </script>
   <style>
     body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
-    .state-section { border-top: 1px solid #2a2d35; padding-top: 2rem; margin-top: 2rem; }
+    .state-label { border-top: 1px solid #27272a; padding-top: 2rem; margin-top: 2.5rem; }
+    /* Toast animation */
+    @keyframes toast-in { from { transform: translateY(16px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
+    .toast { animation: toast-in 0.2s ease-out; }
   </style>
 </head>
 <body class="bg-background text-text-primary min-h-screen">
@@ -45,6 +53,7 @@
           <span class="w-2 h-2 rounded-full bg-active-green animate-pulse"></span>
           Pipeline Running
         </span>
+        <!-- Destructive action — triggers confirmation modal -->
         <button class="px-4 py-2 bg-error-red/10 text-error-red border border-error-red/20 rounded-lg text-sm font-medium hover:bg-error-red/20 transition-colors">
           Stop Pipeline
         </button>
@@ -56,9 +65,9 @@
       <input
         type="text"
         placeholder="Video source path or URL..."
-        class="flex-1 px-4 py-2.5 bg-surface border border-border rounded-lg text-text-primary placeholder-text-secondary text-sm focus:outline-none focus:border-transit-blue/50 focus:ring-1 focus:ring-transit-blue/20"
+        class="flex-1 px-4 py-2.5 bg-surface border border-border rounded-lg text-text-primary placeholder-text-muted text-sm focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-accent/20"
       >
-      <button class="px-5 py-2.5 bg-transit-blue text-white rounded-lg text-sm font-medium hover:bg-transit-blue/90 transition-colors whitespace-nowrap">
+      <button class="px-5 py-2.5 bg-accent text-white rounded-lg text-sm font-medium hover:bg-accent-hover transition-colors whitespace-nowrap">
         + Add Channel
       </button>
     </div>
@@ -67,132 +76,138 @@
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
 
       <!-- Channel 0 — Analytics phase, active -->
-      <a href="#" class="block bg-surface border border-border rounded-xl p-4 hover:border-transit-blue/30 transition-colors group">
+      <a href="#" class="block bg-surface border border-border rounded-xl p-4 hover:border-accent/30 transition-colors group">
         <div class="flex items-center justify-between mb-3">
           <div class="flex items-center gap-2">
             <span class="text-sm font-semibold">Channel 0</span>
             <span class="px-2 py-0.5 bg-transit-blue/10 text-transit-blue text-xs rounded-full font-medium">Analytics</span>
           </div>
-          <svg class="w-4 h-4 text-text-secondary group-hover:text-text-primary transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
-        </div>
-        <p class="text-text-secondary text-xs truncate mb-3">/data/lytle_south.mp4</p>
-        <div class="flex items-center justify-between text-xs">
-          <div class="flex items-center gap-3">
-            <span class="text-transit-blue">47 transit</span>
-            <span class="text-stagnant-amber">3 stagnant</span>
+          <div class="flex items-center gap-2">
+            <button class="text-text-muted hover:text-error-red transition-colors opacity-0 group-hover:opacity-100" title="Remove channel">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+            </button>
+            <svg class="w-4 h-4 text-text-muted group-hover:text-text-primary transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
           </div>
-          <span class="text-text-secondary">30 fps</span>
+        </div>
+        <p class="text-text-muted text-xs truncate mb-3">/data/lytle_south.mp4</p>
+        <div class="flex items-center justify-between text-xs">
+          <span class="text-text-secondary">50 alerts</span>
+          <span class="text-text-muted">30 fps</span>
         </div>
       </a>
 
-      <!-- Channel 1 — Setup phase -->
-      <a href="#" class="block bg-surface border border-border rounded-xl p-4 hover:border-transit-blue/30 transition-colors group">
+      <!-- Channel 1 — Setup phase (needs attention) -->
+      <a href="#" class="block bg-surface border border-border rounded-xl p-4 hover:border-accent/30 transition-colors group">
         <div class="flex items-center justify-between mb-3">
           <div class="flex items-center gap-2">
             <span class="text-sm font-semibold">Channel 1</span>
-            <span class="px-2 py-0.5 bg-stagnant-amber/10 text-stagnant-amber text-xs rounded-full font-medium">Setup</span>
+            <span class="px-2 py-0.5 bg-stagnant-amber/10 text-stagnant-amber text-xs rounded-full font-medium flex items-center gap-1">
+              <span class="w-1.5 h-1.5 rounded-full bg-stagnant-amber animate-pulse"></span>
+              Setup
+            </span>
           </div>
-          <svg class="w-4 h-4 text-text-secondary group-hover:text-text-primary transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+          <div class="flex items-center gap-2">
+            <button class="text-text-muted hover:text-error-red transition-colors opacity-0 group-hover:opacity-100" title="Remove channel">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+            </button>
+            <svg class="w-4 h-4 text-text-muted group-hover:text-text-primary transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+          </div>
         </div>
-        <p class="text-text-secondary text-xs truncate mb-3">/data/741_73.mp4</p>
+        <p class="text-text-muted text-xs truncate mb-3">/data/741_73.mp4</p>
         <div class="flex items-center justify-between text-xs">
-          <div class="flex items-center gap-3">
-            <span class="text-text-secondary">No alerts yet</span>
-          </div>
-          <span class="text-text-secondary">—</span>
+          <span class="text-text-muted">No alerts yet</span>
+          <span class="text-text-muted">—</span>
         </div>
       </a>
 
       <!-- Channel 2 — Review phase -->
-      <a href="#" class="block bg-surface border border-border rounded-xl p-4 hover:border-transit-blue/30 transition-colors group">
+      <a href="#" class="block bg-surface border border-border rounded-xl p-4 hover:border-accent/30 transition-colors group">
         <div class="flex items-center justify-between mb-3">
           <div class="flex items-center gap-2">
             <span class="text-sm font-semibold">Channel 2</span>
             <span class="px-2 py-0.5 bg-active-green/10 text-active-green text-xs rounded-full font-medium">Review</span>
           </div>
-          <svg class="w-4 h-4 text-text-secondary group-hover:text-text-primary transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
-        </div>
-        <p class="text-text-secondary text-xs truncate mb-3">/data/drugmart_73.mp4</p>
-        <div class="flex items-center justify-between text-xs">
-          <div class="flex items-center gap-3">
-            <span class="text-transit-blue">128 transit</span>
-            <span class="text-stagnant-amber">12 stagnant</span>
+          <div class="flex items-center gap-2">
+            <button class="text-text-muted hover:text-error-red transition-colors opacity-0 group-hover:opacity-100" title="Remove channel">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+            </button>
+            <svg class="w-4 h-4 text-text-muted group-hover:text-text-primary transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
           </div>
-          <span class="text-text-secondary">Idle</span>
+        </div>
+        <p class="text-text-muted text-xs truncate mb-3">/data/drugmart_73.mp4</p>
+        <div class="flex items-center justify-between text-xs">
+          <span class="text-text-secondary">140 alerts</span>
+          <span class="text-text-muted">Idle</span>
         </div>
       </a>
 
     </div>
 
-    <!-- ==================== STATE: Pipeline Stopped ==================== -->
-    <div class="state-section">
-      <p class="text-text-secondary text-xs uppercase tracking-wider mb-4">State: Pipeline Stopped</p>
-
-      <div class="flex items-center justify-between mb-6">
-        <div>
-          <h1 class="text-2xl font-bold">Vehicle Tracker</h1>
-          <p class="text-text-secondary text-sm mt-1">Junction monitoring dashboard</p>
+    <!-- Confirmation Modal (for Stop Pipeline) -->
+    <div class="state-label">
+      <p class="text-text-muted text-xs uppercase tracking-wider mb-4">UX-C: Confirmation Modal (Stop Pipeline)</p>
+      <div class="fixed inset-0 bg-black/60 flex items-center justify-center" style="position:relative; height:220px; border-radius:12px;">
+        <div class="bg-surface border border-border rounded-xl p-6 w-[420px] shadow-2xl">
+          <h3 class="text-base font-semibold mb-2">Stop Pipeline?</h3>
+          <p class="text-text-secondary text-sm mb-5">All in-memory alerts, snapshots, and replay data will be cleared. This cannot be undone.</p>
+          <div class="flex justify-end gap-3">
+            <button class="px-4 py-2 bg-elevated border border-border-strong rounded-lg text-sm text-text-secondary hover:text-text-primary transition-colors">Cancel</button>
+            <button class="px-4 py-2 bg-error-red text-white rounded-lg text-sm font-medium hover:bg-error-red/90 transition-colors">Stop Pipeline</button>
+          </div>
         </div>
-        <div class="flex items-center gap-3">
-          <span class="flex items-center gap-2 text-sm text-text-secondary">
-            <span class="w-2 h-2 rounded-full bg-text-secondary"></span>
-            Pipeline Stopped
-          </span>
-          <button class="px-4 py-2 bg-active-green/10 text-active-green border border-active-green/20 rounded-lg text-sm font-medium hover:bg-active-green/20 transition-colors">
-            Start Pipeline
-          </button>
-        </div>
-      </div>
-
-      <!-- Empty state -->
-      <div class="flex flex-col items-center justify-center py-16 text-center">
-        <div class="w-16 h-16 bg-surface rounded-2xl flex items-center justify-center mb-4">
-          <svg class="w-8 h-8 text-text-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
-        </div>
-        <h3 class="text-lg font-medium mb-1">No active channels</h3>
-        <p class="text-text-secondary text-sm max-w-md">Start the pipeline, then add a video source to begin monitoring a junction.</p>
       </div>
     </div>
 
-    <!-- ==================== STATE: Pipeline Starting (Loading) ==================== -->
-    <div class="state-section">
-      <p class="text-text-secondary text-xs uppercase tracking-wider mb-4">State: Pipeline Starting</p>
+    <!-- Toast Notification -->
+    <div class="state-label">
+      <p class="text-text-muted text-xs uppercase tracking-wider mb-4">UX-B: Toast Notification</p>
+      <div class="flex flex-col items-end gap-2">
+        <div class="toast bg-surface border border-border rounded-lg px-4 py-3 shadow-lg flex items-center gap-3 w-[320px]">
+          <span class="w-2 h-2 rounded-full bg-active-green flex-shrink-0"></span>
+          <span class="text-sm">Pipeline started</span>
+          <span class="text-text-muted text-xs ml-auto">just now</span>
+        </div>
+        <div class="toast bg-surface border border-border rounded-lg px-4 py-3 shadow-lg flex items-center gap-3 w-[320px]">
+          <span class="w-2 h-2 rounded-full bg-active-green flex-shrink-0"></span>
+          <span class="text-sm">Config saved</span>
+          <span class="text-text-muted text-xs ml-auto">just now</span>
+        </div>
+        <div class="toast bg-surface border border-border rounded-lg px-4 py-3 shadow-lg flex items-center gap-3 w-[320px]">
+          <span class="w-2 h-2 rounded-full bg-error-red flex-shrink-0"></span>
+          <span class="text-sm text-error-red">Failed to connect to backend</span>
+          <span class="text-text-muted text-xs ml-auto">just now</span>
+        </div>
+      </div>
+    </div>
 
-      <div class="flex items-center justify-between mb-6">
-        <div>
-          <h1 class="text-2xl font-bold">Vehicle Tracker</h1>
-          <p class="text-text-secondary text-sm mt-1">Junction monitoring dashboard</p>
+    <!-- ==================== STATE: Pipeline Stopped ==================== -->
+    <div class="state-label">
+      <p class="text-text-muted text-xs uppercase tracking-wider mb-4">State: Pipeline Stopped</p>
+
+      <!-- Centered CTA when stopped -->
+      <div class="flex flex-col items-center justify-center py-16 text-center">
+        <div class="w-16 h-16 bg-surface rounded-2xl flex items-center justify-center mb-4">
+          <svg class="w-8 h-8 text-text-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
         </div>
-        <div class="flex items-center gap-3">
-          <span class="flex items-center gap-2 text-sm text-stagnant-amber">
-            <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>
-            Starting...
-          </span>
-          <button disabled class="px-4 py-2 bg-surface border border-border rounded-lg text-sm font-medium text-text-secondary cursor-not-allowed">
-            Starting...
-          </button>
-        </div>
+        <h3 class="text-lg font-medium mb-1">No active channels</h3>
+        <p class="text-text-secondary text-sm max-w-md mb-6">Start the pipeline, then add a video source to begin monitoring a junction.</p>
+        <button class="px-6 py-3 bg-accent text-white rounded-lg text-sm font-medium hover:bg-accent-hover transition-colors">
+          Start Pipeline
+        </button>
       </div>
     </div>
 
     <!-- ==================== STATE: Backend Unreachable ==================== -->
-    <div class="state-section">
-      <p class="text-text-secondary text-xs uppercase tracking-wider mb-4">State: Backend Unreachable</p>
-
-      <div class="flex items-center justify-between mb-6">
-        <div>
-          <h1 class="text-2xl font-bold">Vehicle Tracker</h1>
-          <p class="text-text-secondary text-sm mt-1">Junction monitoring dashboard</p>
-        </div>
-      </div>
+    <div class="state-label">
+      <p class="text-text-muted text-xs uppercase tracking-wider mb-4">State: Backend Unreachable</p>
 
       <div class="bg-error-red/5 border border-error-red/20 rounded-xl p-6 text-center">
         <div class="w-12 h-12 bg-error-red/10 rounded-xl flex items-center justify-center mx-auto mb-3">
           <svg class="w-6 h-6 text-error-red" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z"/></svg>
         </div>
         <h3 class="text-error-red font-medium mb-1">Backend Unreachable</h3>
-        <p class="text-text-secondary text-sm">Cannot connect to the vehicle tracker backend at <code class="text-text-primary bg-surface px-1.5 py-0.5 rounded text-xs">localhost:8000</code>. Make sure the backend container is running.</p>
-        <button class="mt-4 px-4 py-2 bg-surface border border-border rounded-lg text-sm text-text-primary hover:border-text-secondary transition-colors">
+        <p class="text-text-secondary text-sm">Cannot connect to <code class="text-text-primary bg-elevated px-1.5 py-0.5 rounded text-xs">localhost:8000</code></p>
+        <button class="mt-4 px-4 py-2 bg-surface border border-border rounded-lg text-sm text-text-primary hover:border-border-strong transition-colors">
           Retry Connection
         </button>
       </div>


### PR DESCRIPTION
## Summary
- Five standalone HTML mockups with Zinc neutral palette (#09090b/#18181b/#fafafa)
- All PRD inconsistencies fixed (64x64 thumbnails, 300px sidebar, accordion expand, confidence slider)
- UX improvements A-E approved: disabled states, toasts, confirmation modals, undo, stats warnings
- Drawing tool UX: rubber band, vertex handles, close-by-click, line label input

Closes #38

## Test plan
- [x] All 5 mockups render correctly in browser
- [x] Screenshots verified via Playwright
- [x] Design approved by Joel