### PR TITLE
M3 Phase 2: Home page — channel manager

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,20 +1,23 @@
 import { Routes, Route } from "react-router-dom";
 import { HomeProvider } from "./contexts/HomeContext";
+import { ToastProvider } from "./components/Toast";
 import Home from "./pages/Home";
 import Channel from "./pages/Channel";
 
 export default function App() {
   return (
-    <Routes>
-      <Route
-        path="/"
-        element={
-          <HomeProvider>
-            <Home />
-          </HomeProvider>
-        }
-      />
-      <Route path="/channel/:id" element={<Channel />} />
-    </Routes>
+    <ToastProvider>
+      <Routes>
+        <Route
+          path="/"
+          element={
+            <HomeProvider>
+              <Home />
+            </HomeProvider>
+          }
+        />
+        <Route path="/channel/:id" element={<Channel />} />
+      </Routes>
+    </ToastProvider>
   );
 }

--- a/frontend/src/components/ChannelCard.jsx
+++ b/frontend/src/components/ChannelCard.jsx
@@ -1,0 +1,79 @@
+const phaseBadge = {
+  setup: {
+    bg: "bg-stagnant-amber/10",
+    text: "text-stagnant-amber",
+    pulse: true,
+  },
+  analytics: {
+    bg: "bg-transit-blue/10",
+    text: "text-transit-blue",
+    pulse: false,
+  },
+  review: {
+    bg: "bg-active-green/10",
+    text: "text-active-green",
+    pulse: false,
+  },
+};
+
+export default function ChannelCard({ channel, onRemove }) {
+  const badge = phaseBadge[channel.phase] || phaseBadge.setup;
+
+  function handleOpen(e) {
+    // Don't open if clicking the remove button
+    if (e.target.closest("[data-remove]")) return;
+    window.open(`/channel/${channel.channel_id}`, `channel-${channel.channel_id}`);
+  }
+
+  function handleRemove(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    onRemove(channel.channel_id);
+  }
+
+  return (
+    <div
+      onClick={handleOpen}
+      className="bg-surface border border-border rounded-xl p-4 hover:border-accent/30 transition-colors cursor-pointer group"
+    >
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-semibold">
+            Channel {channel.channel_id}
+          </span>
+          <span
+            className={`px-2 py-0.5 ${badge.bg} ${badge.text} text-xs rounded-full font-medium flex items-center gap-1`}
+          >
+            {badge.pulse && (
+              <span className="w-1.5 h-1.5 rounded-full bg-stagnant-amber animate-pulse" />
+            )}
+            {channel.phase.charAt(0).toUpperCase() + channel.phase.slice(1)}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            data-remove
+            onClick={handleRemove}
+            className="text-text-muted hover:text-error-red transition-colors opacity-0 group-hover:opacity-100"
+            title="Remove channel"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+          <svg className="w-4 h-4 text-text-muted group-hover:text-text-primary transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+          </svg>
+        </div>
+      </div>
+      <p className="text-text-muted text-xs truncate mb-3">{channel.source}</p>
+      <div className="flex items-center justify-between text-xs">
+        <span className="text-text-secondary">
+          {channel.alert_count > 0
+            ? `${channel.alert_count} alerts`
+            : "No alerts yet"}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ConfirmModal.jsx
+++ b/frontend/src/components/ConfirmModal.jsx
@@ -1,0 +1,39 @@
+export default function ConfirmModal({
+  open,
+  title,
+  message,
+  confirmLabel = "Confirm",
+  confirmVariant = "danger",
+  onConfirm,
+  onCancel,
+}) {
+  if (!open) return null;
+
+  const confirmClass =
+    confirmVariant === "danger"
+      ? "bg-error-red text-white hover:bg-error-red/90"
+      : "bg-accent text-white hover:bg-accent-hover";
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-40">
+      <div className="bg-surface border border-border rounded-xl p-6 w-[420px] shadow-2xl">
+        <h3 className="text-base font-semibold mb-2">{title}</h3>
+        <p className="text-text-secondary text-sm mb-5">{message}</p>
+        <div className="flex justify-end gap-3">
+          <button
+            onClick={onCancel}
+            className="px-4 py-2 bg-elevated border border-border-strong rounded-lg text-sm text-text-secondary hover:text-text-primary transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${confirmClass}`}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Toast.jsx
+++ b/frontend/src/components/Toast.jsx
@@ -1,0 +1,56 @@
+import { createContext, useCallback, useContext, useRef, useState } from "react";
+
+const ToastContext = createContext(null);
+
+export function ToastProvider({ children }) {
+  const [toasts, setToasts] = useState([]);
+  const idRef = useRef(0);
+
+  const addToast = useCallback((message, variant = "success") => {
+    const id = ++idRef.current;
+    setToasts((prev) => [...prev, { id, message, variant, exiting: false }]);
+    setTimeout(() => {
+      setToasts((prev) =>
+        prev.map((t) => (t.id === id ? { ...t, exiting: true } : t))
+      );
+      setTimeout(() => {
+        setToasts((prev) => prev.filter((t) => t.id !== id));
+      }, 150);
+    }, 3000);
+  }, []);
+
+  return (
+    <ToastContext.Provider value={addToast}>
+      {children}
+      <div className="fixed bottom-4 right-4 flex flex-col items-end gap-2 z-50">
+        {toasts.map((t) => (
+          <div
+            key={t.id}
+            className={`bg-surface border border-border rounded-lg px-4 py-3 shadow-lg flex items-center gap-3 min-w-[280px] ${
+              t.exiting ? "animate-toast-out" : "animate-toast-in"
+            }`}
+          >
+            <span
+              className={`w-2 h-2 rounded-full flex-shrink-0 ${
+                t.variant === "error" ? "bg-error-red" : "bg-active-green"
+              }`}
+            />
+            <span
+              className={`text-sm ${
+                t.variant === "error" ? "text-error-red" : "text-text-primary"
+              }`}
+            >
+              {t.message}
+            </span>
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error("useToast must be used within ToastProvider");
+  return ctx;
+}

--- a/frontend/src/contexts/HomeContext.jsx
+++ b/frontend/src/contexts/HomeContext.jsx
@@ -5,20 +5,35 @@ const HomeContext = createContext(null);
 const initialState = {
   channels: [],
   pipelineStarted: false,
+  loading: false,
 };
 
 function homeReducer(state, action) {
   switch (action.type) {
     case "SET_CHANNELS":
-      return { ...state, channels: action.channels };
+      return {
+        ...state,
+        channels: action.channels,
+        pipelineStarted: action.pipelineStarted,
+      };
     case "SET_PIPELINE_STARTED":
       return { ...state, pipelineStarted: action.started };
-    case "UPDATE_CHANNEL": {
-      const updated = state.channels.map((ch) =>
-        ch.channel_id === action.channel.channel_id ? action.channel : ch
+    case "SET_LOADING":
+      return { ...state, loading: action.loading };
+    case "ADD_CHANNEL": {
+      const exists = state.channels.some(
+        (ch) => ch.channel_id === action.channel.channel_id
       );
-      return { ...state, channels: updated };
+      if (exists) return state;
+      return { ...state, channels: [...state.channels, action.channel] };
     }
+    case "REMOVE_CHANNEL":
+      return {
+        ...state,
+        channels: state.channels.filter(
+          (ch) => ch.channel_id !== action.channelId
+        ),
+      };
     case "PHASE_CHANGED": {
       const updated = state.channels.map((ch) =>
         ch.channel_id === action.channel
@@ -27,6 +42,16 @@ function homeReducer(state, action) {
       );
       return { ...state, channels: updated };
     }
+    case "INCREMENT_ALERT": {
+      const updated = state.channels.map((ch) =>
+        ch.channel_id === action.channel
+          ? { ...ch, alert_count: (ch.alert_count || 0) + 1 }
+          : ch
+      );
+      return { ...state, channels: updated };
+    }
+    case "PIPELINE_STOPPED":
+      return { ...state, pipelineStarted: false, channels: [] };
     default:
       return state;
   }

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,17 +1,292 @@
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useHome } from "../contexts/HomeContext";
+import { useToast } from "../components/Toast";
+import ChannelCard from "../components/ChannelCard";
+import ConfirmModal from "../components/ConfirmModal";
+import {
+  getChannels,
+  startPipeline,
+  stopPipeline,
+  addChannel,
+  removeChannel,
+} from "../api/rest";
+import { createWs } from "../api/ws";
 
 export default function Home() {
-  const { state } = useHome();
+  const { state, dispatch } = useHome();
+  const toast = useToast();
+  const [source, setSource] = useState("");
+  const [confirmStop, setConfirmStop] = useState(false);
+  const [confirmRemove, setConfirmRemove] = useState(null);
+  const [error, setError] = useState(null);
+  const wsRef = useRef(null);
 
+  // Fetch initial state
+  useEffect(() => {
+    getChannels()
+      .then((data) => {
+        dispatch({
+          type: "SET_CHANNELS",
+          channels: data.channels,
+          pipelineStarted: data.pipeline_started,
+        });
+        setError(null);
+      })
+      .catch(() => setError("backend"));
+  }, [dispatch]);
+
+  // WebSocket connection
+  useEffect(() => {
+    const ws = createWs({
+      types: [
+        "pipeline_event",
+        "phase_changed",
+        "transit_alert",
+        "stagnant_alert",
+      ],
+    });
+
+    ws.on("pipeline_event", (msg) => {
+      if (msg.event === "started") {
+        dispatch({ type: "SET_PIPELINE_STARTED", started: true });
+      } else if (msg.event === "stopped") {
+        dispatch({ type: "PIPELINE_STOPPED" });
+      }
+    });
+
+    ws.on("phase_changed", (msg) => {
+      dispatch({
+        type: "PHASE_CHANGED",
+        channel: msg.channel,
+        phase: msg.phase,
+      });
+    });
+
+    ws.on("transit_alert", (msg) => {
+      dispatch({ type: "INCREMENT_ALERT", channel: msg.channel });
+    });
+
+    ws.on("stagnant_alert", (msg) => {
+      dispatch({ type: "INCREMENT_ALERT", channel: msg.channel });
+    });
+
+    ws.connect();
+    wsRef.current = ws;
+
+    return () => ws.close();
+  }, [dispatch]);
+
+  const handleStart = useCallback(async () => {
+    dispatch({ type: "SET_LOADING", loading: true });
+    try {
+      await startPipeline();
+      dispatch({ type: "SET_PIPELINE_STARTED", started: true });
+      toast("Pipeline started");
+    } catch (e) {
+      toast(e.message, "error");
+    } finally {
+      dispatch({ type: "SET_LOADING", loading: false });
+    }
+  }, [dispatch, toast]);
+
+  const handleStop = useCallback(async () => {
+    setConfirmStop(false);
+    dispatch({ type: "SET_LOADING", loading: true });
+    try {
+      await stopPipeline();
+      dispatch({ type: "PIPELINE_STOPPED" });
+      toast("Pipeline stopped");
+    } catch (e) {
+      toast(e.message, "error");
+    } finally {
+      dispatch({ type: "SET_LOADING", loading: false });
+    }
+  }, [dispatch, toast]);
+
+  const handleAddChannel = useCallback(async () => {
+    if (!source.trim()) return;
+    try {
+      const data = await addChannel(source.trim());
+      dispatch({
+        type: "ADD_CHANNEL",
+        channel: {
+          channel_id: data.channel_id,
+          source: source.trim(),
+          phase: "setup",
+          alert_count: 0,
+        },
+      });
+      window.open(`/channel/${data.channel_id}`, `channel-${data.channel_id}`);
+      setSource("");
+      toast("Channel added");
+    } catch (e) {
+      toast(e.message, "error");
+    }
+  }, [source, dispatch, toast]);
+
+  const handleRemoveChannel = useCallback(
+    async (channelId) => {
+      setConfirmRemove(null);
+      try {
+        await removeChannel(channelId);
+        dispatch({ type: "REMOVE_CHANNEL", channelId });
+        toast("Channel removed");
+      } catch (e) {
+        toast(e.message, "error");
+      }
+    },
+    [dispatch, toast]
+  );
+
+  // Backend unreachable
+  if (error === "backend") {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-6">
+        <div className="bg-error-red/5 border border-error-red/20 rounded-xl p-6 text-center max-w-md">
+          <div className="w-12 h-12 bg-error-red/10 rounded-xl flex items-center justify-center mx-auto mb-3">
+            <svg className="w-6 h-6 text-error-red" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
+            </svg>
+          </div>
+          <h3 className="text-error-red font-medium mb-1">Backend Unreachable</h3>
+          <p className="text-text-secondary text-sm">
+            Cannot connect to{" "}
+            <code className="text-text-primary bg-elevated px-1.5 py-0.5 rounded text-xs">
+              localhost:8000
+            </code>
+          </p>
+          <button
+            onClick={() => window.location.reload()}
+            className="mt-4 px-4 py-2 bg-surface border border-border rounded-lg text-sm text-text-primary hover:border-border-strong transition-colors"
+          >
+            Retry Connection
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Pipeline stopped — centered CTA
+  if (!state.pipelineStarted && !state.loading) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center p-6">
+        <div className="w-16 h-16 bg-surface rounded-2xl flex items-center justify-center mb-4">
+          <svg className="w-8 h-8 text-text-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
+          </svg>
+        </div>
+        <h3 className="text-lg font-medium mb-1">No active channels</h3>
+        <p className="text-text-secondary text-sm max-w-md text-center mb-6">
+          Start the pipeline, then add a video source to begin monitoring a
+          junction.
+        </p>
+        <button
+          onClick={handleStart}
+          className="px-6 py-3 bg-accent text-white rounded-lg text-sm font-medium hover:bg-accent-hover transition-colors"
+        >
+          Start Pipeline
+        </button>
+      </div>
+    );
+  }
+
+  // Pipeline running (or loading)
   return (
-    <div className="min-h-screen p-6">
-      <h1 className="text-2xl font-bold mb-4">Vehicle Tracker</h1>
-      <p className="text-text-secondary">
-        Pipeline: {state.pipelineStarted ? "Running" : "Stopped"}
-      </p>
-      <p className="text-text-secondary mt-2">
-        Channels: {state.channels.length}
-      </p>
+    <div className="max-w-5xl mx-auto p-6">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold">Vehicle Tracker</h1>
+          <p className="text-text-secondary text-sm mt-1">
+            Junction monitoring dashboard
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          {state.loading ? (
+            <>
+              <span className="flex items-center gap-2 text-sm text-stagnant-amber">
+                <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                </svg>
+                Starting...
+              </span>
+              <button disabled className="px-4 py-2 bg-surface border border-border rounded-lg text-sm font-medium text-text-muted cursor-not-allowed">
+                Starting...
+              </button>
+            </>
+          ) : (
+            <>
+              <span className="flex items-center gap-2 text-sm text-active-green">
+                <span className="w-2 h-2 rounded-full bg-active-green animate-pulse" />
+                Pipeline Running
+              </span>
+              <button
+                onClick={() => setConfirmStop(true)}
+                className="px-4 py-2 bg-error-red/10 text-error-red border border-error-red/20 rounded-lg text-sm font-medium hover:bg-error-red/20 transition-colors"
+              >
+                Stop Pipeline
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Add Channel */}
+      <div className="flex gap-3 mb-6">
+        <input
+          type="text"
+          placeholder="Video source path or URL..."
+          value={source}
+          onChange={(e) => setSource(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && handleAddChannel()}
+          className="flex-1 px-4 py-2.5 bg-surface border border-border rounded-lg text-text-primary placeholder-text-muted text-sm focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-accent/20"
+        />
+        <button
+          onClick={handleAddChannel}
+          disabled={!source.trim() || state.loading}
+          className="px-5 py-2.5 bg-accent text-white rounded-lg text-sm font-medium hover:bg-accent-hover transition-colors whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          + Add Channel
+        </button>
+      </div>
+
+      {/* Channel Cards */}
+      {state.channels.length === 0 ? (
+        <div className="text-center py-12 text-text-muted text-sm">
+          No channels yet. Add a video source above to get started.
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {state.channels.map((ch) => (
+            <ChannelCard
+              key={ch.channel_id}
+              channel={ch}
+              onRemove={(id) => setConfirmRemove(id)}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Confirmation modals */}
+      <ConfirmModal
+        open={confirmStop}
+        title="Stop Pipeline?"
+        message="All in-memory alerts, snapshots, and replay data will be cleared. This cannot be undone."
+        confirmLabel="Stop Pipeline"
+        confirmVariant="danger"
+        onConfirm={handleStop}
+        onCancel={() => setConfirmStop(false)}
+      />
+      <ConfirmModal
+        open={confirmRemove !== null}
+        title="Remove Channel?"
+        message={`Channel ${confirmRemove} and all its alerts will be removed.`}
+        confirmLabel="Remove"
+        confirmVariant="danger"
+        onConfirm={() => handleRemoveChannel(confirmRemove)}
+        onCancel={() => setConfirmRemove(null)}
+      />
     </div>
   );
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -5,11 +5,16 @@ export default {
   theme: {
     extend: {
       colors: {
-        background: "#0f1117",
-        surface: "#1a1d23",
-        border: "#2a2d35",
-        "text-primary": "#e1e1e1",
-        "text-secondary": "#9ca3af",
+        background: "#09090b",
+        surface: "#18181b",
+        elevated: "#27272a",
+        border: "#27272a",
+        "border-strong": "#3f3f46",
+        "text-primary": "#fafafa",
+        "text-secondary": "#a1a1aa",
+        "text-muted": "#71717a",
+        accent: "#6366f1",
+        "accent-hover": "#818cf8",
         "transit-blue": "#60a5fa",
         "stagnant-amber": "#fbbf24",
         "active-green": "#4ade80",
@@ -24,10 +29,20 @@ export default {
           from: { height: "var(--radix-accordion-content-height)" },
           to: { height: "0" },
         },
+        "toast-in": {
+          from: { transform: "translateY(16px)", opacity: "0" },
+          to: { transform: "translateY(0)", opacity: "1" },
+        },
+        "toast-out": {
+          from: { transform: "translateY(0)", opacity: "1" },
+          to: { transform: "translateY(16px)", opacity: "0" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
+        "toast-in": "toast-in 0.2s ease-out",
+        "toast-out": "toast-out 0.15s ease-in forwards",
       },
     },
   },


### PR DESCRIPTION
## Summary
- Zinc neutral palette (#09090b/#18181b/#fafafa) applied to Tailwind config
- Pipeline start/stop with loading states and confirmation modal (UX-C)
- Add channel input → opens `/channel/{id}` in new browser tab
- Channel status cards: phase badge (Setup amber pulse, Analytics blue, Review green), source path, alert count
- WebSocket integration: `phase_changed` updates card phase, `transit_alert`/`stagnant_alert` increment alert count
- Toast notification system with success/error variants, auto-dismiss 3s (UX-B)
- Confirmation modal for Stop Pipeline + Remove Channel (UX-C)
- Backend unreachable error state with Retry button
- Empty state CTA when pipeline stopped

Closes #31

## Test plan
- [x] Pipeline stopped → centered "Start Pipeline" CTA
- [x] Click Start → pipeline starts, header changes, toast appears
- [x] Add channel → card appears, new tab opens at `/channel/0`
- [x] Stop Pipeline → confirmation modal → confirm → clears channels, returns to empty state
- [x] Backend unreachable → error state with retry button
- [x] Toast notifications work (success green, error red)