### PR TITLE
M3 Phase 4: Drawing tools — ROI polygon + entry/exit lines

### DIFF
--- a/frontend/src/components/DrawingCanvas.jsx
+++ b/frontend/src/components/DrawingCanvas.jsx
@@ -1,0 +1,370 @@
+import { useCallback, useEffect, useRef } from "react";
+import {
+  getContainedImageGeometry,
+  clientToImageCoords,
+  imageToDisplayCoords,
+} from "../lib/coords";
+
+// Colors matching mockup
+const ROI_STROKE = "#6366f1";
+const ROI_FILL = "rgba(99,102,241,0.12)";
+const VERTEX_FILL = "#fafafa";
+const VERTEX_STROKE = "#09090b";
+const FIRST_VERTEX_FILL = "#4ade80";
+const RUBBER_BAND_ALPHA = 0.6;
+const CLOSE_PREVIEW_ALPHA = 0.4;
+const LINE_COLORS = ["#4ade80", "#fbbf24", "#60a5fa", "#f87171"];
+const LABEL_BG = "rgba(0,0,0,0.7)";
+const CLOSE_THRESHOLD_PX = 12; // distance to first vertex to close polygon
+
+/**
+ * DrawingCanvas — transparent canvas overlay for ROI polygon + entry/exit lines.
+ *
+ * Props:
+ *   imgRef        - ref to the MJPEG <img> element
+ *   tool          - "roi" | "line" | null (current drawing tool)
+ *   roi           - array of {x,y} points in image space (completed polygon)
+ *   lines         - array of { label, start: {x,y}, end: {x,y} } in image space
+ *   onRoiChange   - callback(newRoi)
+ *   onLineAdd     - callback({ label, start, end })
+ *   pendingPoints - array of {x,y} for in-progress drawing (managed by parent)
+ *   onPendingChange - callback(newPending)
+ *   onLineComplete  - callback({ start, end }) — line placed, parent shows label input
+ */
+export default function DrawingCanvas({
+  imgRef,
+  tool,
+  roi,
+  lines,
+  onRoiChange,
+  pendingPoints,
+  onPendingChange,
+  onLineComplete,
+}) {
+  const canvasRef = useRef(null);
+  const mousePos = useRef(null);
+  const geoRef = useRef(null);
+
+  // Recompute geometry and redraw
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    const img = imgRef.current;
+    if (!canvas || !img) return;
+
+    const ctx = canvas.getContext("2d");
+    const geo = getContainedImageGeometry(img);
+    geoRef.current = geo;
+
+    // Size canvas to container
+    const parent = canvas.parentElement;
+    if (canvas.width !== parent.clientWidth || canvas.height !== parent.clientHeight) {
+      canvas.width = parent.clientWidth;
+      canvas.height = parent.clientHeight;
+    }
+
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    // Draw completed ROI polygon
+    if (roi.length >= 3) {
+      ctx.beginPath();
+      const first = imageToDisplayCoords(roi[0].x, roi[0].y, geo);
+      ctx.moveTo(first.x, first.y);
+      for (let i = 1; i < roi.length; i++) {
+        const p = imageToDisplayCoords(roi[i].x, roi[i].y, geo);
+        ctx.lineTo(p.x, p.y);
+      }
+      ctx.closePath();
+      ctx.fillStyle = ROI_FILL;
+      ctx.fill();
+      ctx.strokeStyle = ROI_STROKE;
+      ctx.lineWidth = 2;
+      ctx.stroke();
+
+      // Vertices
+      for (let i = 0; i < roi.length; i++) {
+        const p = imageToDisplayCoords(roi[i].x, roi[i].y, geo);
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, 5, 0, Math.PI * 2);
+        ctx.fillStyle = VERTEX_FILL;
+        ctx.fill();
+        ctx.strokeStyle = VERTEX_STROKE;
+        ctx.lineWidth = 2;
+        ctx.stroke();
+      }
+    }
+
+    // Draw in-progress ROI polygon
+    if (tool === "roi" && pendingPoints.length > 0 && roi.length < 3) {
+      ctx.beginPath();
+      const first = imageToDisplayCoords(pendingPoints[0].x, pendingPoints[0].y, geo);
+      ctx.moveTo(first.x, first.y);
+      for (let i = 1; i < pendingPoints.length; i++) {
+        const p = imageToDisplayCoords(pendingPoints[i].x, pendingPoints[i].y, geo);
+        ctx.lineTo(p.x, p.y);
+      }
+
+      // Rubber band to cursor
+      if (mousePos.current) {
+        const mp = imageToDisplayCoords(mousePos.current.x, mousePos.current.y, geo);
+        ctx.lineTo(mp.x, mp.y);
+      }
+
+      ctx.strokeStyle = ROI_STROKE;
+      ctx.lineWidth = 2;
+      ctx.globalAlpha = RUBBER_BAND_ALPHA;
+      ctx.stroke();
+      ctx.globalAlpha = 1;
+
+      // Closing preview (dashed line from cursor back to first vertex)
+      if (pendingPoints.length >= 2 && mousePos.current) {
+        const mp = imageToDisplayCoords(mousePos.current.x, mousePos.current.y, geo);
+        ctx.beginPath();
+        ctx.moveTo(mp.x, mp.y);
+        ctx.lineTo(first.x, first.y);
+        ctx.setLineDash([6, 4]);
+        ctx.strokeStyle = ROI_STROKE;
+        ctx.globalAlpha = CLOSE_PREVIEW_ALPHA;
+        ctx.stroke();
+        ctx.setLineDash([]);
+        ctx.globalAlpha = 1;
+      }
+
+      // Vertices
+      for (let i = 0; i < pendingPoints.length; i++) {
+        const p = imageToDisplayCoords(pendingPoints[i].x, pendingPoints[i].y, geo);
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, i === 0 ? 6 : 5, 0, Math.PI * 2);
+        ctx.fillStyle = i === 0 ? FIRST_VERTEX_FILL : VERTEX_FILL;
+        ctx.fill();
+        ctx.strokeStyle = VERTEX_STROKE;
+        ctx.lineWidth = 2;
+        ctx.stroke();
+      }
+    }
+
+    // Draw completed entry/exit lines
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const color = LINE_COLORS[i % LINE_COLORS.length];
+      const s = imageToDisplayCoords(line.start.x, line.start.y, geo);
+      const e = imageToDisplayCoords(line.end.x, line.end.y, geo);
+
+      ctx.beginPath();
+      ctx.moveTo(s.x, s.y);
+      ctx.lineTo(e.x, e.y);
+      ctx.strokeStyle = color;
+      ctx.lineWidth = 3;
+      ctx.stroke();
+
+      // Endpoints
+      for (const p of [s, e]) {
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, 5, 0, Math.PI * 2);
+        ctx.fillStyle = VERTEX_FILL;
+        ctx.fill();
+        ctx.strokeStyle = VERTEX_STROKE;
+        ctx.lineWidth = 2;
+        ctx.stroke();
+      }
+
+      // Label at midpoint
+      const midX = (s.x + e.x) / 2;
+      const midY = (s.y + e.y) / 2;
+      const label = line.label || `Line ${i + 1}`;
+      ctx.font = "600 12px -apple-system, BlinkMacSystemFont, sans-serif";
+      const textWidth = ctx.measureText(label).width;
+      const padX = 10;
+      const padY = 4;
+      const rectW = textWidth + padX * 2;
+      const rectH = 20;
+
+      ctx.fillStyle = LABEL_BG;
+      ctx.beginPath();
+      ctx.roundRect(midX - rectW / 2, midY - rectH - 4, rectW, rectH, 4);
+      ctx.fill();
+
+      ctx.fillStyle = color;
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillText(label, midX, midY - rectH / 2 - 4 + padY);
+    }
+
+    // Draw in-progress line (single point placed)
+    if (tool === "line" && pendingPoints.length === 1) {
+      const color = LINE_COLORS[lines.length % LINE_COLORS.length];
+      const s = imageToDisplayCoords(pendingPoints[0].x, pendingPoints[0].y, geo);
+
+      // Endpoint
+      ctx.beginPath();
+      ctx.arc(s.x, s.y, 5, 0, Math.PI * 2);
+      ctx.fillStyle = VERTEX_FILL;
+      ctx.fill();
+      ctx.strokeStyle = VERTEX_STROKE;
+      ctx.lineWidth = 2;
+      ctx.stroke();
+
+      // Rubber band to cursor
+      if (mousePos.current) {
+        const mp = imageToDisplayCoords(mousePos.current.x, mousePos.current.y, geo);
+        ctx.beginPath();
+        ctx.moveTo(s.x, s.y);
+        ctx.lineTo(mp.x, mp.y);
+        ctx.strokeStyle = color;
+        ctx.lineWidth = 3;
+        ctx.globalAlpha = RUBBER_BAND_ALPHA;
+        ctx.stroke();
+        ctx.globalAlpha = 1;
+      }
+    }
+
+    // Draw tooltip when in drawing mode
+    if (tool && pendingPoints.length > 0) {
+      let tip = "";
+      if (tool === "roi") {
+        tip = pendingPoints.length >= 3
+          ? "Click first point or double-click to close \u00b7 Ctrl+Z to undo \u00b7 Esc to cancel"
+          : "Click to add points \u00b7 Ctrl+Z to undo \u00b7 Esc to cancel";
+      } else if (tool === "line") {
+        tip = "Click to place second endpoint \u00b7 Esc to cancel";
+      }
+      if (tip) {
+        ctx.font = "12px -apple-system, BlinkMacSystemFont, sans-serif";
+        const tw = ctx.measureText(tip).width;
+        ctx.fillStyle = "rgba(0,0,0,0.7)";
+        ctx.beginPath();
+        ctx.roundRect(12, 12, tw + 20, 28, 6);
+        ctx.fill();
+        ctx.fillStyle = "#a1a1aa";
+        ctx.textAlign = "left";
+        ctx.textBaseline = "middle";
+        ctx.fillText(tip, 22, 26);
+      }
+    }
+  }, [roi, lines, tool, pendingPoints, imgRef]);
+
+  // Animation loop for smooth rubber band
+  useEffect(() => {
+    let raf;
+    function loop() {
+      draw();
+      raf = requestAnimationFrame(loop);
+    }
+    // Only run animation loop when actively drawing
+    if (tool && pendingPoints.length > 0) {
+      raf = requestAnimationFrame(loop);
+    } else {
+      draw();
+    }
+    return () => cancelAnimationFrame(raf);
+  }, [draw, tool, pendingPoints.length]);
+
+  // ResizeObserver
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const observer = new ResizeObserver(() => draw());
+    observer.observe(canvas.parentElement);
+    return () => observer.disconnect();
+  }, [draw]);
+
+  // Mouse move tracking
+  const handleMouseMove = useCallback(
+    (e) => {
+      const img = imgRef.current;
+      if (!img || !tool) return;
+      const coords = clientToImageCoords(e.clientX, e.clientY, img);
+      mousePos.current = coords;
+    },
+    [imgRef, tool]
+  );
+
+  // Click handler
+  const handleClick = useCallback(
+    (e) => {
+      const img = imgRef.current;
+      if (!img || !tool) return;
+
+      const coords = clientToImageCoords(e.clientX, e.clientY, img);
+      if (!coords) return; // letterbox click
+
+      if (tool === "roi") {
+        // Check if clicking near first vertex to close polygon
+        if (pendingPoints.length >= 3) {
+          const first = pendingPoints[0];
+          const geo = geoRef.current;
+          if (geo) {
+            const fp = imageToDisplayCoords(first.x, first.y, geo);
+            const cp = imageToDisplayCoords(coords.x, coords.y, geo);
+            const dist = Math.hypot(fp.x - cp.x, fp.y - cp.y);
+            if (dist < CLOSE_THRESHOLD_PX) {
+              // Close polygon
+              onRoiChange([...pendingPoints]);
+              onPendingChange([]);
+              return;
+            }
+          }
+        }
+        onPendingChange([...pendingPoints, coords]);
+      } else if (tool === "line") {
+        if (pendingPoints.length === 0) {
+          onPendingChange([coords]);
+        } else {
+          // Line complete — 2 points placed
+          onLineComplete({
+            start: pendingPoints[0],
+            end: coords,
+          });
+          onPendingChange([]);
+        }
+      }
+    },
+    [imgRef, tool, pendingPoints, onRoiChange, onPendingChange, onLineComplete]
+  );
+
+  // Double-click to close ROI polygon
+  const handleDblClick = useCallback(
+    (e) => {
+      if (tool !== "roi" || pendingPoints.length < 3) return;
+      e.preventDefault();
+      onRoiChange([...pendingPoints]);
+      onPendingChange([]);
+    },
+    [tool, pendingPoints, onRoiChange, onPendingChange]
+  );
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    function handleKeyDown(e) {
+      if (!tool) return;
+
+      // Ctrl+Z — undo last point
+      if (e.ctrlKey && e.key === "z") {
+        e.preventDefault();
+        if (pendingPoints.length > 0) {
+          onPendingChange(pendingPoints.slice(0, -1));
+        }
+      }
+
+      // Escape — cancel current drawing
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onPendingChange([]);
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [tool, pendingPoints, onPendingChange]);
+
+  const cursor = tool ? "crosshair" : "default";
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="absolute inset-0 w-full h-full"
+      style={{ cursor, pointerEvents: tool ? "auto" : "none" }}
+      onClick={handleClick}
+      onDoubleClick={handleDblClick}
+      onMouseMove={handleMouseMove}
+    />
+  );
+}

--- a/frontend/src/components/DrawingTools.jsx
+++ b/frontend/src/components/DrawingTools.jsx
@@ -1,0 +1,331 @@
+import { useCallback, useEffect, useState } from "react";
+import { saveSiteConfig, loadSiteConfig, listSiteConfigs } from "../api/rest";
+import { useToast } from "./Toast";
+
+const LINE_COLORS = ["bg-active-green", "bg-stagnant-amber", "bg-transit-blue", "bg-error-red"];
+const DEFAULT_LABELS = ["North", "South", "East", "West"];
+
+/**
+ * DrawingTools sidebar — tool selector, lines list, site config, Start Analytics.
+ *
+ * Props:
+ *   tool            - "roi" | "line" | null
+ *   onToolChange    - callback(tool)
+ *   roi             - completed ROI polygon points
+ *   lines           - completed entry/exit lines
+ *   pendingPoints   - in-progress points
+ *   onClearRoi      - callback()
+ *   onClearLine     - callback(index)
+ *   onClearAll      - callback()
+ *   onUndo          - callback()
+ *   onStartAnalytics - callback()
+ *   labelInput      - { start, end } | null — line awaiting label
+ *   onLabelConfirm  - callback(label) — confirm label for pending line
+ *   onLabelCancel   - callback() — cancel pending line
+ *   onLoadConfig    - callback({ roi, lines }) — loaded config to render
+ */
+export default function DrawingTools({
+  tool,
+  onToolChange,
+  roi,
+  lines,
+  pendingPoints,
+  onClearRoi,
+  onClearLine,
+  onClearAll,
+  onUndo,
+  onStartAnalytics,
+  labelInput,
+  onLabelConfirm,
+  onLabelCancel,
+  onLoadConfig,
+  loading,
+}) {
+  const toast = useToast();
+  const [siteId, setSiteId] = useState("");
+  const [savedSites, setSavedSites] = useState([]);
+  const [selectedSite, setSelectedSite] = useState("");
+  const [labelValue, setLabelValue] = useState("");
+
+  // Fetch saved site configs on mount
+  useEffect(() => {
+    listSiteConfigs()
+      .then((data) => setSavedSites(data.sites || []))
+      .catch(() => {});
+  }, []);
+
+  // Reset label input when new line is placed
+  useEffect(() => {
+    if (labelInput) {
+      setLabelValue(DEFAULT_LABELS[lines.length] || "");
+    }
+  }, [labelInput, lines.length]);
+
+  const handleSave = useCallback(async () => {
+    if (!siteId.trim()) {
+      toast("Enter a site ID", "error");
+      return;
+    }
+    if (roi.length < 3) {
+      toast("Draw ROI polygon first", "error");
+      return;
+    }
+    const entryExitLines = {};
+    for (const line of lines) {
+      entryExitLines[line.label] = {
+        label: line.label,
+        start: [line.start.x, line.start.y],
+        end: [line.end.x, line.end.y],
+      };
+    }
+    try {
+      await saveSiteConfig({
+        site_id: siteId.trim(),
+        roi_polygon: roi.map((p) => [p.x, p.y]),
+        entry_exit_lines: entryExitLines,
+      });
+      toast("Config saved");
+      // Refresh list
+      const data = await listSiteConfigs();
+      setSavedSites(data.sites || []);
+    } catch (e) {
+      toast(e.message, "error");
+    }
+  }, [siteId, roi, lines, toast]);
+
+  const handleLoad = useCallback(async () => {
+    if (!selectedSite) return;
+    try {
+      const data = await loadSiteConfig(selectedSite);
+      const loadedRoi = (data.roi_polygon || []).map(([x, y]) => ({ x, y }));
+      const loadedLines = Object.entries(data.entry_exit_lines || {}).map(
+        ([key, val]) => ({
+          label: val.label || key,
+          start: { x: val.start[0], y: val.start[1] },
+          end: { x: val.end[0], y: val.end[1] },
+        })
+      );
+      onLoadConfig({ roi: loadedRoi, lines: loadedLines });
+      setSiteId(selectedSite);
+      toast("Config loaded");
+    } catch (e) {
+      toast(e.message, "error");
+    }
+  }, [selectedSite, onLoadConfig, toast]);
+
+  const handleLabelSubmit = useCallback(() => {
+    const label = labelValue.trim() || DEFAULT_LABELS[lines.length] || "Line";
+    onLabelConfirm(label);
+    setLabelValue("");
+  }, [labelValue, lines.length, onLabelConfirm]);
+
+  const hasRoi = roi.length >= 3;
+  const isDrawing = pendingPoints.length > 0;
+
+  return (
+    <div className="w-[300px] bg-surface border-l border-border flex flex-col shrink-0">
+      {/* Drawing Tools */}
+      <div className="p-4 border-b border-border">
+        <h3 className="text-sm font-semibold mb-3">Drawing Tools</h3>
+        <div className="space-y-2">
+          {/* ROI tool */}
+          <button
+            onClick={() => onToolChange(tool === "roi" ? null : "roi")}
+            disabled={hasRoi}
+            className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm transition-colors ${
+              tool === "roi"
+                ? "bg-accent/10 border border-accent/30 text-accent"
+                : hasRoi
+                  ? "bg-background border border-border text-text-muted cursor-not-allowed"
+                  : "bg-background border border-border text-text-secondary hover:text-text-primary hover:border-border-strong cursor-pointer"
+            }`}
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v14a1 1 0 01-1 1H5a1 1 0 01-1-1V5z" />
+            </svg>
+            Draw ROI Polygon
+            {tool === "roi" && <span className="ml-auto text-xs text-accent/60">Active</span>}
+            {hasRoi && <span className="ml-auto text-xs text-active-green/60">Done</span>}
+          </button>
+
+          {/* Line tool */}
+          <button
+            onClick={() => onToolChange(tool === "line" ? null : "line")}
+            disabled={lines.length >= 4 || !!labelInput}
+            className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm transition-colors ${
+              tool === "line"
+                ? "bg-accent/10 border border-accent/30 text-accent"
+                : lines.length >= 4
+                  ? "bg-background border border-border text-text-muted cursor-not-allowed"
+                  : "bg-background border border-border text-text-secondary hover:text-text-primary hover:border-border-strong cursor-pointer"
+            }`}
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 12h16" />
+            </svg>
+            Add Entry/Exit Line
+            {lines.length > 0 && <span className="ml-auto text-xs text-text-muted">{lines.length}/4</span>}
+          </button>
+
+          {/* Undo */}
+          <button
+            onClick={onUndo}
+            disabled={!isDrawing}
+            className="w-full flex items-center gap-3 px-3 py-2.5 bg-background border border-border rounded-lg text-sm text-text-secondary hover:text-text-primary hover:border-border-strong transition-colors disabled:text-text-muted disabled:cursor-not-allowed disabled:hover:border-border"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 10h10a5 5 0 015 5v2M3 10l4-4M3 10l4 4" />
+            </svg>
+            Undo Last Point
+            <span className="ml-auto text-xs text-text-muted">Ctrl+Z</span>
+          </button>
+
+          {/* Clear All */}
+          <button
+            onClick={onClearAll}
+            disabled={!hasRoi && lines.length === 0 && !isDrawing}
+            className="w-full flex items-center gap-3 px-3 py-2.5 bg-background border border-border rounded-lg text-sm text-text-secondary hover:text-error-red hover:border-error-red/30 transition-colors disabled:text-text-muted disabled:cursor-not-allowed disabled:hover:text-text-muted disabled:hover:border-border"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+            </svg>
+            Clear All
+          </button>
+        </div>
+      </div>
+
+      {/* Label Input (shown when line just placed) */}
+      {labelInput && (
+        <div className="p-4 border-b border-border">
+          <h3 className="text-sm font-semibold mb-3">Label This Line</h3>
+          <input
+            type="text"
+            value={labelValue}
+            onChange={(e) => setLabelValue(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleLabelSubmit()}
+            placeholder="Label..."
+            autoFocus
+            className="w-full px-3 py-2 bg-background border border-border rounded-lg text-sm text-text-primary text-center focus:outline-none focus:border-accent/50 mb-2"
+          />
+          <div className="flex gap-1 mb-2">
+            {DEFAULT_LABELS.map((l) => (
+              <button
+                key={l}
+                onClick={() => setLabelValue(l)}
+                className={`flex-1 px-1 py-1.5 text-xs rounded transition-colors ${
+                  labelValue === l
+                    ? "text-accent bg-accent/10 font-medium"
+                    : "text-text-muted hover:text-text-primary bg-background"
+                }`}
+              >
+                {l.charAt(0)}
+              </button>
+            ))}
+          </div>
+          <div className="flex gap-2">
+            <button
+              onClick={handleLabelSubmit}
+              className="flex-1 px-3 py-1.5 bg-accent text-white rounded-lg text-xs font-medium hover:bg-accent-hover transition-colors"
+            >
+              Confirm
+            </button>
+            <button
+              onClick={onLabelCancel}
+              className="flex-1 px-3 py-1.5 bg-background border border-border rounded-lg text-xs text-text-secondary hover:text-text-primary transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Entry/Exit Lines List */}
+      {lines.length > 0 && (
+        <div className="p-4 border-b border-border">
+          <h3 className="text-sm font-semibold mb-3">Entry/Exit Lines</h3>
+          <div className="space-y-2">
+            {lines.map((line, i) => (
+              <div key={i} className="flex items-center justify-between px-3 py-2 bg-background rounded-lg">
+                <div className="flex items-center gap-2">
+                  <span className={`w-2.5 h-2.5 rounded-full ${LINE_COLORS[i % LINE_COLORS.length]}`} />
+                  <span className="text-sm">{line.label}</span>
+                </div>
+                <button
+                  onClick={() => onClearLine(i)}
+                  className="text-text-muted hover:text-error-red transition-colors"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Site Configuration */}
+      <div className="p-4 flex-1">
+        <h3 className="text-sm font-semibold mb-3">Site Configuration</h3>
+        <div className="space-y-3">
+          <div>
+            <label className="text-xs text-text-muted block mb-1">Site ID</label>
+            <input
+              type="text"
+              value={siteId}
+              onChange={(e) => setSiteId(e.target.value)}
+              placeholder="e.g. 741_73"
+              className="w-full px-3 py-2 bg-background border border-border rounded-lg text-sm text-text-primary focus:outline-none focus:border-accent/50"
+            />
+          </div>
+          <div className="flex gap-2">
+            <button
+              onClick={handleSave}
+              disabled={!hasRoi || !siteId.trim()}
+              className="flex-1 px-3 py-2 bg-accent text-white rounded-lg text-sm font-medium hover:bg-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Save
+            </button>
+            <button
+              onClick={handleLoad}
+              disabled={!selectedSite}
+              className="flex-1 px-3 py-2 bg-background border border-border rounded-lg text-sm text-text-secondary hover:text-text-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Load
+            </button>
+          </div>
+          {savedSites.length > 0 && (
+            <div>
+              <label className="text-xs text-text-muted block mb-1">Saved Configs</label>
+              <select
+                value={selectedSite}
+                onChange={(e) => setSelectedSite(e.target.value)}
+                className="w-full px-3 py-2 bg-background border border-border rounded-lg text-sm text-text-primary focus:outline-none focus:border-accent/50"
+              >
+                <option value="">Select a config...</option>
+                {savedSites.map((s) => (
+                  <option key={s} value={s}>{s}</option>
+                ))}
+              </select>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Start Analytics */}
+      <div className="p-4 border-t border-border">
+        <button
+          onClick={onStartAnalytics}
+          disabled={!hasRoi || loading}
+          className={`w-full px-4 py-2.5 rounded-lg text-sm font-medium transition-colors ${
+            hasRoi
+              ? "bg-active-green/10 text-active-green border border-active-green/20 hover:bg-active-green/20"
+              : "bg-elevated border border-border text-text-muted cursor-not-allowed"
+          }`}
+        >
+          {loading ? "Starting..." : hasRoi ? "Start Analytics" : "Draw ROI to continue"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/coords.js
+++ b/frontend/src/lib/coords.js
@@ -1,0 +1,59 @@
+/**
+ * Coordinate mapping for object-fit:contain images.
+ *
+ * All drawing coordinates are stored in original pixel space (e.g. 1920x1080)
+ * and converted to/from display coordinates for canvas rendering.
+ */
+
+/**
+ * Compute the displayed image geometry within an <img> element using object-fit:contain.
+ * Returns { scale, offsetX, offsetY, displayWidth, displayHeight }.
+ */
+export function getContainedImageGeometry(imgElement) {
+  const { naturalWidth, naturalHeight, clientWidth, clientHeight } = imgElement;
+  if (!naturalWidth || !naturalHeight) {
+    return { scale: 1, offsetX: 0, offsetY: 0, displayWidth: clientWidth, displayHeight: clientHeight };
+  }
+
+  const scaleX = clientWidth / naturalWidth;
+  const scaleY = clientHeight / naturalHeight;
+  const scale = Math.min(scaleX, scaleY);
+
+  const displayWidth = naturalWidth * scale;
+  const displayHeight = naturalHeight * scale;
+  const offsetX = (clientWidth - displayWidth) / 2;
+  const offsetY = (clientHeight - displayHeight) / 2;
+
+  return { scale, offsetX, offsetY, displayWidth, displayHeight };
+}
+
+/**
+ * Convert a mouse event's clientX/clientY to original image pixel coordinates.
+ * Returns { x, y } in image space, or null if click is in letterbox area.
+ */
+export function clientToImageCoords(clientX, clientY, imgElement) {
+  const rect = imgElement.getBoundingClientRect();
+  const geo = getContainedImageGeometry(imgElement);
+
+  const relX = clientX - rect.left - geo.offsetX;
+  const relY = clientY - rect.top - geo.offsetY;
+
+  if (relX < 0 || relY < 0 || relX > geo.displayWidth || relY > geo.displayHeight) {
+    return null; // click in letterbox area
+  }
+
+  return {
+    x: relX / geo.scale,
+    y: relY / geo.scale,
+  };
+}
+
+/**
+ * Convert image pixel coordinates back to display (canvas) coordinates.
+ */
+export function imageToDisplayCoords(imgX, imgY, geo) {
+  return {
+    x: imgX * geo.scale + geo.offsetX,
+    y: imgY * geo.scale + geo.offsetY,
+  };
+}

--- a/frontend/src/pages/Channel.jsx
+++ b/frontend/src/pages/Channel.jsx
@@ -3,6 +3,8 @@ import { useParams } from "react-router-dom";
 import { ChannelProvider, useChannel } from "../contexts/ChannelContext";
 import { AlertProvider, useAlerts } from "../contexts/AlertContext";
 import { useToast } from "../components/Toast";
+import DrawingCanvas from "../components/DrawingCanvas";
+import DrawingTools from "../components/DrawingTools";
 import { getChannel, getAlerts, setChannelPhase, updateConfig } from "../api/rest";
 import { createWs } from "../api/ws";
 
@@ -33,10 +35,9 @@ function PhaseIndicator({ current }) {
   );
 }
 
-function VideoPanel({ channelId, pipelineStarted }) {
+function VideoPanel({ channelId, pipelineStarted, phase, imgRef, drawingProps }) {
   const [loaded, setLoaded] = useState(false);
   const [errored, setErrored] = useState(false);
-  const imgRef = useRef(null);
 
   // Reset state when pipeline status changes
   useEffect(() => {
@@ -66,7 +67,7 @@ function VideoPanel({ channelId, pipelineStarted }) {
   return (
     <div className="flex-1 bg-black flex items-center justify-center relative">
       {!loaded && (
-        <div className="absolute inset-0 flex items-center justify-center">
+        <div className="absolute inset-0 flex items-center justify-center z-10">
           <svg className="w-6 h-6 text-text-muted animate-spin" fill="none" viewBox="0 0 24 24">
             <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
             <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
@@ -81,94 +82,10 @@ function VideoPanel({ channelId, pipelineStarted }) {
         onLoad={() => setLoaded(true)}
         onError={() => setErrored(true)}
       />
-    </div>
-  );
-}
-
-function ControlPanel({ phase }) {
-  const { state, dispatch } = useChannel();
-  const toast = useToast();
-  const [confidence, setConfidence] = useState(0.5);
-  const [loading, setLoading] = useState(false);
-  const debounceRef = useRef(null);
-
-  const handleConfidenceChange = useCallback(
-    (e) => {
-      const val = parseFloat(e.target.value);
-      setConfidence(val);
-      clearTimeout(debounceRef.current);
-      debounceRef.current = setTimeout(() => {
-        updateConfig({ confidence_threshold: val }).catch(() => {});
-      }, 300);
-    },
-    []
-  );
-
-  const handleStartAnalytics = useCallback(async () => {
-    setLoading(true);
-    try {
-      await setChannelPhase(state.channelId, "analytics");
-      dispatch({ type: "SET_PHASE", phase: "analytics" });
-      toast("Analytics started");
-    } catch (e) {
-      toast(e.message, "error");
-    } finally {
-      setLoading(false);
-    }
-  }, [state.channelId, dispatch, toast]);
-
-  if (phase !== "setup") return null;
-
-  return (
-    <div className="w-[300px] bg-surface border-l border-border flex flex-col shrink-0">
-      {/* Drawing Tools Placeholder */}
-      <div className="p-4 border-b border-border">
-        <h3 className="text-sm font-semibold mb-3">Drawing Tools</h3>
-        <div className="space-y-2">
-          <button disabled className="w-full flex items-center gap-3 px-3 py-2.5 bg-background border border-border rounded-lg text-sm text-text-muted cursor-not-allowed">
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v14a1 1 0 01-1 1H5a1 1 0 01-1-1V5z"/></svg>
-            Draw ROI Polygon
-          </button>
-          <button disabled className="w-full flex items-center gap-3 px-3 py-2.5 bg-background border border-border rounded-lg text-sm text-text-muted cursor-not-allowed">
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 12h16"/></svg>
-            Add Entry/Exit Line
-          </button>
-        </div>
-        <p className="text-text-muted text-xs mt-2">Drawing tools available in Phase 4</p>
-      </div>
-
-      {/* Confidence Threshold */}
-      <div className="p-4 flex-1">
-        <h3 className="text-sm font-semibold mb-3">Configuration</h3>
-        <div>
-          <label className="text-xs text-text-muted block mb-1">Confidence Threshold</label>
-          <div className="flex items-center gap-3">
-            <input
-              type="range"
-              min="0"
-              max="1"
-              step="0.01"
-              value={confidence}
-              onChange={handleConfidenceChange}
-              className="flex-1 h-1.5 bg-elevated rounded-full appearance-none [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3.5 [&::-webkit-slider-thumb]:h-3.5 [&::-webkit-slider-thumb]:bg-accent [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:cursor-pointer"
-            />
-            <span className="text-xs text-text-secondary w-8 text-right">
-              {confidence.toFixed(2)}
-            </span>
-          </div>
-        </div>
-      </div>
-
-      {/* Start Analytics */}
-      <div className="p-4 border-t border-border">
-        <button
-          onClick={handleStartAnalytics}
-          disabled={loading}
-          className="w-full px-4 py-2.5 bg-active-green/10 text-active-green border border-active-green/20 rounded-lg text-sm font-medium hover:bg-active-green/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {loading ? "Starting..." : "Start Analytics"}
-        </button>
-      </div>
+      {/* Drawing canvas overlay — visible in Setup phase when stream loaded */}
+      {phase === "setup" && loaded && (
+        <DrawingCanvas imgRef={imgRef} {...drawingProps} />
+      )}
     </div>
   );
 }
@@ -204,8 +121,17 @@ function ChannelContent() {
   const { dispatch: alertDispatch } = useAlerts();
   const toast = useToast();
   const wsRef = useRef(null);
+  const imgRef = useRef(null);
   const [error, setError] = useState(null);
-  const [loading, setLoading] = useState(true);
+  const [pageLoading, setPageLoading] = useState(true);
+  const [phaseLoading, setPhaseLoading] = useState(false);
+
+  // Drawing state
+  const [tool, setTool] = useState(null);
+  const [roi, setRoi] = useState([]);
+  const [lines, setLines] = useState([]);
+  const [pendingPoints, setPendingPoints] = useState([]);
+  const [labelInput, setLabelInput] = useState(null);
 
   // Load channel state on mount
   useEffect(() => {
@@ -230,7 +156,7 @@ function ChannelContent() {
       } catch {
         if (!cancelled) setError("load");
       } finally {
-        if (!cancelled) setLoading(false);
+        if (!cancelled) setPageLoading(false);
       }
     }
     load();
@@ -285,7 +211,87 @@ function ChannelContent() {
     return () => ws.close();
   }, [channelId, dispatch, alertDispatch, toast]);
 
-  if (loading) {
+  // Drawing tool callbacks
+  const handleToolChange = useCallback((newTool) => {
+    setTool(newTool);
+    setPendingPoints([]);
+    setLabelInput(null);
+  }, []);
+
+  const handleRoiChange = useCallback((newRoi) => {
+    setRoi(newRoi);
+    setTool(null);
+  }, []);
+
+  const handleLineComplete = useCallback((line) => {
+    setLabelInput(line);
+    setTool(null);
+  }, []);
+
+  const handleLabelConfirm = useCallback((label) => {
+    if (!labelInput) return;
+    setLines((prev) => [...prev, { label, start: labelInput.start, end: labelInput.end }]);
+    setLabelInput(null);
+  }, [labelInput]);
+
+  const handleLabelCancel = useCallback(() => {
+    setLabelInput(null);
+  }, []);
+
+  const handleClearRoi = useCallback(() => {
+    setRoi([]);
+  }, []);
+
+  const handleClearLine = useCallback((index) => {
+    setLines((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const handleClearAll = useCallback(() => {
+    setRoi([]);
+    setLines([]);
+    setPendingPoints([]);
+    setTool(null);
+    setLabelInput(null);
+  }, []);
+
+  const handleUndo = useCallback(() => {
+    if (pendingPoints.length > 0) {
+      setPendingPoints((prev) => prev.slice(0, -1));
+    }
+  }, [pendingPoints.length]);
+
+  const handleLoadConfig = useCallback(({ roi: loadedRoi, lines: loadedLines }) => {
+    setRoi(loadedRoi);
+    setLines(loadedLines);
+    setPendingPoints([]);
+    setTool(null);
+    setLabelInput(null);
+  }, []);
+
+  const handleStartAnalytics = useCallback(async () => {
+    setPhaseLoading(true);
+    try {
+      await setChannelPhase(channelId, "analytics");
+      dispatch({ type: "SET_PHASE", phase: "analytics" });
+      toast("Analytics started");
+    } catch (e) {
+      toast(e.message, "error");
+    } finally {
+      setPhaseLoading(false);
+    }
+  }, [channelId, dispatch, toast]);
+
+  // Confidence threshold (debounced)
+  const handleConfidenceChange = useCallback((e) => {
+    const val = parseFloat(e.target.value);
+    // Debounce is handled inline
+    clearTimeout(handleConfidenceChange._timer);
+    handleConfidenceChange._timer = setTimeout(() => {
+      updateConfig({ confidence_threshold: val }).catch(() => {});
+    }, 300);
+  }, []);
+
+  if (pageLoading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <svg className="w-6 h-6 text-text-muted animate-spin" fill="none" viewBox="0 0 24 24">
@@ -316,6 +322,16 @@ function ChannelContent() {
   }
 
   const { phase, source, pipelineStarted } = state;
+
+  const drawingProps = {
+    tool,
+    roi,
+    lines,
+    onRoiChange: handleRoiChange,
+    pendingPoints,
+    onPendingChange: setPendingPoints,
+    onLineComplete: handleLineComplete,
+  };
 
   return (
     <div className="min-h-screen flex flex-col bg-background">
@@ -357,13 +373,35 @@ function ChannelContent() {
       <div className="flex flex-1 min-h-0">
         {/* Video Panel */}
         <div className="flex-1 flex flex-col min-w-0">
-          <VideoPanel channelId={channelId} pipelineStarted={pipelineStarted} />
+          <VideoPanel
+            channelId={channelId}
+            pipelineStarted={pipelineStarted}
+            phase={phase}
+            imgRef={imgRef}
+            drawingProps={drawingProps}
+          />
           <StatsBar phase={phase} />
         </div>
 
         {/* Right Sidebar */}
         {phase === "setup" ? (
-          <ControlPanel phase={phase} />
+          <DrawingTools
+            tool={tool}
+            onToolChange={handleToolChange}
+            roi={roi}
+            lines={lines}
+            pendingPoints={pendingPoints}
+            onClearRoi={handleClearRoi}
+            onClearLine={handleClearLine}
+            onClearAll={handleClearAll}
+            onUndo={handleUndo}
+            onStartAnalytics={handleStartAnalytics}
+            labelInput={labelInput}
+            onLabelConfirm={handleLabelConfirm}
+            onLabelCancel={handleLabelCancel}
+            onLoadConfig={handleLoadConfig}
+            loading={phaseLoading}
+          />
         ) : (
           <AnalyticsPlaceholder />
         )}


### PR DESCRIPTION
## Summary
- Canvas overlay on MJPEG video with coordinate mapping (`lib/coords.js`) for object-fit:contain letterboxing — all points stored in original pixel space (1920x1080)
- ROI polygon tool: click to add vertices, close by clicking near first vertex or double-click, semi-transparent fill + stroke, first vertex green
- Entry/exit line tool: click 2 points, label input popover with N/S/E/W quick-select, colored lines with label at midpoint, max 4 lines
- Drawing tools sidebar: tool selector, Undo (Ctrl+Z), Clear All, per-line delete, entry/exit lines list
- Site config save/load: `POST /site/config`, `GET /site/configs`, `GET /site/config?site_id=X` — loaded config renders on canvas
- Start Analytics button gated on ROI presence ("Draw ROI to continue" when no ROI)
- ResizeObserver keeps canvas sized to container
- Keyboard shortcuts: Ctrl+Z undo, Escape cancel

Closes #33

## Test plan
- [ ] Click "Draw ROI Polygon", click 4+ points on video, close polygon — verify fill + stroke render
- [ ] Click "Add Entry/Exit Line", click 2 points, enter label — verify line + label render
- [ ] Draw 4 lines — verify "Add Entry/Exit Line" disables at 4/4
- [ ] Ctrl+Z undoes last point during drawing
- [ ] Escape cancels current drawing
- [ ] Delete individual line from list — verify removal + count update
- [ ] Clear All — verify everything resets
- [ ] Save config with site ID — verify `POST /site/config` succeeds
- [ ] Load saved config — verify ROI + lines render, buttons update
- [ ] Start Analytics enabled only when ROI is drawn
- [ ] Resize window during drawing — verify no coordinate drift
- [ ] `./dev.sh exec backend pytest backend/tests/ -v` — 270 tests pass