### PR TITLE
M3 Phase 5: Analytics phase — alert feed + stats bar

### DIFF
--- a/frontend/src/components/AlertFeed.jsx
+++ b/frontend/src/components/AlertFeed.jsx
@@ -1,0 +1,219 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { useAlerts } from "../contexts/AlertContext";
+import { snapshotUrl } from "../api/rest";
+
+const CARD_HEIGHT = 76; // px per alert card
+const FILTERS = [
+  { key: "all", label: "All" },
+  { key: "transit_alert", label: "Transit" },
+  { key: "stagnant_alert", label: "Stagnant" },
+];
+
+function formatRelativeTime(timestamp) {
+  if (!timestamp) return "";
+  const now = Date.now();
+  const ts = typeof timestamp === "number" ? timestamp : new Date(timestamp).getTime();
+  const diff = Math.max(0, Math.floor((now - ts) / 1000));
+  if (diff < 5) return "just now";
+  if (diff < 60) return `${diff}s ago`;
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return `${Math.floor(diff / 86400)}d ago`;
+}
+
+function AlertCard({ alert }) {
+  const isTransit = alert.type === "transit_alert";
+  const dotColor = isTransit ? "bg-transit-blue" : "bg-stagnant-amber";
+  const textColor = isTransit ? "text-transit-blue" : "text-stagnant-amber";
+
+  let directionLabel = "Stagnant";
+  if (isTransit) {
+    const entry = alert.entry_arm || alert.entry_label || "?";
+    const exit = alert.exit_arm || alert.exit_label || "?";
+    // Use short arm names (first letter uppercase)
+    const e = entry.charAt(0).toUpperCase();
+    const x = exit.charAt(0).toUpperCase();
+    directionLabel = `${e} \u21A3 ${x}`;
+  }
+
+  const label = alert.label || "vehicle";
+  const trackId = alert.track_id ?? "?";
+  const duration = alert.duration_frames
+    ? `${(alert.duration_frames / 30).toFixed(1)}s`
+    : isTransit
+      ? ""
+      : alert.stationary_duration_frames
+        ? `${(alert.stationary_duration_frames / 30).toFixed(0)}s`
+        : "";
+  const method = alert.method || "";
+
+  return (
+    <div className="px-3 py-2.5 border-b border-border/50 cursor-default">
+      <div className="flex gap-3">
+        {/* Thumbnail */}
+        <div className="w-16 h-16 rounded-lg bg-background flex-shrink-0 overflow-hidden">
+          {alert.track_id != null ? (
+            <img
+              src={snapshotUrl(alert.track_id)}
+              alt={`Track ${trackId}`}
+              className="w-full h-full object-cover"
+              onError={(e) => { e.target.style.display = "none"; }}
+            />
+          ) : (
+            <div className="w-full h-full bg-gradient-to-br from-zinc-700 to-zinc-800" />
+          )}
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-0.5">
+            <span className={`w-1.5 h-1.5 rounded-full ${dotColor}`} />
+            <span className={`text-xs font-medium ${textColor}`}>{directionLabel}</span>
+            <span className="text-[10px] text-text-muted ml-auto">
+              {formatRelativeTime(alert.timestamp)}
+            </span>
+          </div>
+          <div className="text-xs text-text-secondary truncate">
+            {label} #{trackId}
+            {duration && ` \u00b7 ${duration}`}
+          </div>
+          {method && (
+            <div className="text-[10px] text-text-muted mt-0.5">{method}</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function AlertFeed({ alertCount }) {
+  const { state, dispatch } = useAlerts();
+  const parentRef = useRef(null);
+  const [newCount, setNewCount] = useState(0);
+  const [atTop, setAtTop] = useState(true);
+  const prevLenRef = useRef(state.alerts.length);
+
+  // Filtered alerts
+  const filtered = useMemo(() => {
+    if (state.filter === "all") return state.alerts;
+    return state.alerts.filter((a) => a.type === state.filter);
+  }, [state.alerts, state.filter]);
+
+  // Virtualizer
+  const virtualizer = useVirtualizer({
+    count: filtered.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => CARD_HEIGHT,
+    overscan: 10,
+  });
+
+  // Track if user is at top of scroll
+  const handleScroll = useCallback(() => {
+    const el = parentRef.current;
+    if (!el) return;
+    const isAtTop = el.scrollTop < 20;
+    setAtTop(isAtTop);
+    if (isAtTop) setNewCount(0);
+  }, []);
+
+  // Auto-scroll when new alerts arrive and user is at top
+  useEffect(() => {
+    const len = filtered.length;
+    const prevLen = prevLenRef.current;
+    prevLenRef.current = len;
+
+    if (len > prevLen) {
+      if (atTop) {
+        // Already at top — scroll stays at top (prepend)
+        setNewCount(0);
+      } else {
+        setNewCount((c) => c + (len - prevLen));
+      }
+    }
+  }, [filtered.length, atTop]);
+
+  const jumpToTop = useCallback(() => {
+    parentRef.current?.scrollTo({ top: 0, behavior: "smooth" });
+    setNewCount(0);
+    setAtTop(true);
+  }, []);
+
+  return (
+    <div className="w-[300px] bg-surface border-l border-border flex flex-col shrink-0">
+      {/* Filter Bar */}
+      <div className="px-3 py-2.5 border-b border-border flex items-center justify-between">
+        <div className="flex items-center gap-1 bg-background rounded-lg p-0.5">
+          {FILTERS.map((f) => {
+            const count = f.key === "all"
+              ? state.alerts.length
+              : state.alerts.filter((a) => a.type === f.key).length;
+            return (
+              <button
+                key={f.key}
+                onClick={() => dispatch({ type: "SET_FILTER", filter: f.key })}
+                className={`px-2 py-1 text-xs font-medium rounded-md transition-colors ${
+                  state.filter === f.key
+                    ? "bg-text-primary/10 text-text-primary"
+                    : "text-text-muted hover:text-text-primary"
+                }`}
+              >
+                {f.label} ({count})
+              </button>
+            );
+          })}
+        </div>
+
+        {/* New alerts badge */}
+        {newCount > 0 && (
+          <button
+            onClick={jumpToTop}
+            className="px-2 py-0.5 bg-transit-blue/10 text-transit-blue text-[10px] rounded-full font-medium animate-pulse"
+          >
+            {newCount} new ↓
+          </button>
+        )}
+      </div>
+
+      {/* Scrollable Alert List */}
+      <div
+        ref={parentRef}
+        className="flex-1 overflow-y-auto"
+        onScroll={handleScroll}
+      >
+        {filtered.length === 0 ? (
+          <div className="flex items-center justify-center h-full">
+            <p className="text-text-muted text-xs">Waiting for alerts...</p>
+          </div>
+        ) : (
+          <div
+            style={{
+              height: `${virtualizer.getTotalSize()}px`,
+              width: "100%",
+              position: "relative",
+            }}
+          >
+            {virtualizer.getVirtualItems().map((virtualRow) => {
+              const alert = filtered[virtualRow.index];
+              return (
+                <div
+                  key={alert.alert_id || virtualRow.index}
+                  style={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    width: "100%",
+                    height: `${virtualRow.size}px`,
+                    transform: `translateY(${virtualRow.start}px)`,
+                  }}
+                >
+                  <AlertCard alert={alert} />
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/StatsBar.jsx
+++ b/frontend/src/components/StatsBar.jsx
@@ -1,0 +1,67 @@
+import { useChannel } from "../contexts/ChannelContext";
+import { useAlerts } from "../contexts/AlertContext";
+
+function fpsColor(fps) {
+  if (fps == null) return "text-text-muted";
+  if (fps < 5) return "text-error-red";
+  if (fps < 15) return "text-stagnant-amber";
+  return "text-active-green";
+}
+
+function inferenceColor(ms) {
+  if (ms == null) return "text-text-muted";
+  if (ms > 40) return "text-error-red";
+  if (ms > 20) return "text-stagnant-amber";
+  return "text-text-primary";
+}
+
+const PHASE_COLORS = {
+  setup: "text-stagnant-amber",
+  analytics: "text-transit-blue",
+  review: "text-active-green",
+};
+
+export default function StatsBar() {
+  const { state } = useChannel();
+  const { state: alertState } = useAlerts();
+  const { stats, phase } = state;
+
+  if (phase !== "analytics") return null;
+
+  const fps = stats?.fps;
+  const tracks = stats?.active_tracks;
+  const inferenceMs = stats?.inference_ms;
+  const alertCount = alertState.alerts.length;
+
+  return (
+    <div className="bg-surface border-t border-border px-4 py-2 flex items-center gap-6 text-xs shrink-0">
+      <span className="text-text-muted">
+        FPS:{" "}
+        <span className={`font-medium ${fpsColor(fps)}`}>
+          {fps != null ? fps.toFixed(1) : "—"}
+        </span>
+      </span>
+      <span className="text-text-muted">
+        Tracks:{" "}
+        <span className="text-text-primary font-medium">
+          {tracks ?? "—"}
+        </span>
+      </span>
+      <span className="text-text-muted">
+        Inference:{" "}
+        <span className={`font-medium ${inferenceColor(inferenceMs)}`}>
+          {inferenceMs != null ? `${inferenceMs.toFixed(1)}ms` : "—"}
+        </span>
+      </span>
+      <span className="text-text-muted">
+        Phase:{" "}
+        <span className={`font-medium ${PHASE_COLORS[phase] || "text-text-primary"}`}>
+          {phase ? phase.charAt(0).toUpperCase() + phase.slice(1) : "—"}
+        </span>
+      </span>
+      <div className="ml-auto text-text-secondary">
+        {alertCount} alert{alertCount !== 1 ? "s" : ""}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/contexts/AlertContext.jsx
+++ b/frontend/src/contexts/AlertContext.jsx
@@ -9,10 +9,20 @@ const initialState = {
 
 function alertReducer(state, action) {
   switch (action.type) {
-    case "SET_ALERTS":
-      return { ...state, alerts: action.alerts };
-    case "ADD_ALERT":
+    case "SET_ALERTS": {
+      // Backfill: merge with existing alerts, dedup by alert_id
+      const existingIds = new Set(state.alerts.map((a) => a.alert_id));
+      const newAlerts = action.alerts.filter((a) => !existingIds.has(a.alert_id));
+      // Existing (from WS) go first (newest), then backfilled
+      return { ...state, alerts: [...state.alerts, ...newAlerts] };
+    }
+    case "ADD_ALERT": {
+      // Skip duplicate (WS might re-deliver)
+      if (state.alerts.some((a) => a.alert_id === action.alert.alert_id)) {
+        return state;
+      }
       return { ...state, alerts: [action.alert, ...state.alerts] };
+    }
     case "SET_FILTER":
       return { ...state, filter: action.filter };
     default:

--- a/frontend/src/pages/Channel.jsx
+++ b/frontend/src/pages/Channel.jsx
@@ -3,8 +3,10 @@ import { useParams } from "react-router-dom";
 import { ChannelProvider, useChannel } from "../contexts/ChannelContext";
 import { AlertProvider, useAlerts } from "../contexts/AlertContext";
 import { useToast } from "../components/Toast";
+import AlertFeed from "../components/AlertFeed";
 import DrawingCanvas from "../components/DrawingCanvas";
 import DrawingTools from "../components/DrawingTools";
+import StatsBar from "../components/StatsBar";
 import { getChannel, getAlerts, setChannelPhase, updateConfig } from "../api/rest";
 import { createWs } from "../api/ws";
 
@@ -86,30 +88,6 @@ function VideoPanel({ channelId, pipelineStarted, phase, imgRef, drawingProps })
       {phase === "setup" && loaded && (
         <DrawingCanvas imgRef={imgRef} {...drawingProps} />
       )}
-    </div>
-  );
-}
-
-function AnalyticsPlaceholder() {
-  return (
-    <div className="w-[300px] bg-surface border-l border-border flex flex-col shrink-0">
-      <div className="p-4 border-b border-border">
-        <h3 className="text-sm font-semibold mb-2">Alert Feed</h3>
-        <p className="text-text-muted text-xs">Alerts will appear here during analytics.</p>
-      </div>
-      <div className="flex-1 flex items-center justify-center">
-        <p className="text-text-muted text-xs">Waiting for alerts...</p>
-      </div>
-    </div>
-  );
-}
-
-function StatsBar({ phase }) {
-  if (phase !== "analytics") return null;
-
-  return (
-    <div className="bg-surface border-t border-border px-4 py-2 flex items-center gap-6 shrink-0">
-      <span className="text-xs text-text-muted">Stats bar — Phase 5</span>
     </div>
   );
 }
@@ -380,7 +358,7 @@ function ChannelContent() {
             imgRef={imgRef}
             drawingProps={drawingProps}
           />
-          <StatsBar phase={phase} />
+          <StatsBar />
         </div>
 
         {/* Right Sidebar */}
@@ -403,7 +381,7 @@ function ChannelContent() {
             loading={phaseLoading}
           />
         ) : (
-          <AnalyticsPlaceholder />
+          <AlertFeed />
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- **AlertFeed** component: virtual scrolling via `@tanstack/react-virtual`, compact alert cards with 64x64 thumbnails, direction labels (N ↣ S), transit blue / stagnant amber color coding, relative timestamps
- **Filter buttons**: All / Transit / Stagnant with counts, client-side filtering
- **Auto-scroll**: stays at top for new alerts, "N new ↓" badge when scrolled down
- **StatsBar**: FPS (green/amber/red thresholds), active tracks, inference latency, phase, alert count — data from `stats_update` WS messages
- **AlertContext** updated: deduplication on both `SET_ALERTS` (backfill) and `ADD_ALERT` (WS) by `alert_id`
- 270 backend tests passing

Closes #34

## Test plan
- [ ] Start analytics — verify empty alert feed shows "Waiting for alerts..."
- [ ] Stats bar shows "—" placeholders until stats_update arrives
- [ ] Filter buttons show correct counts (0/0/0 when empty)
- [ ] Setup phase shows drawing tools (not alert feed)
- [ ] Analytics phase shows alert feed + stats bar
- [ ] Verify virtual scrolling keeps DOM nodes low with many alerts
- [ ] `./dev.sh exec backend pytest backend/tests/ -v` — 270 tests pass