### PR TITLE
M3 Phase 6: Replay backend — clip extraction + replay endpoint

### DIFF
--- a/backend/api/deps.py
+++ b/backend/api/deps.py
@@ -3,6 +3,7 @@
 from fastapi import Request
 
 from backend.pipeline.alerts import AlertStore
+from backend.pipeline.clip_extractor import ClipExtractor
 from backend.pipeline.protocol import PipelineBackend
 
 
@@ -12,3 +13,7 @@ def get_backend(request: Request) -> PipelineBackend:
 
 def get_alert_store(request: Request) -> AlertStore:
     return request.app.state.alert_store
+
+
+def get_clip_extractor(request: Request) -> ClipExtractor:
+    return request.app.state.clip_extractor

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -1,9 +1,9 @@
 """Pipeline control REST endpoints."""
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from fastapi.responses import Response
+from fastapi.responses import FileResponse, JSONResponse, Response
 
-from backend.api.deps import get_alert_store, get_backend
+from backend.api.deps import get_alert_store, get_backend, get_clip_extractor
 from backend.api.models import (
     AddChannelRequest,
     ChannelAddedResponse,
@@ -17,6 +17,7 @@ from backend.api.models import (
 import backend.config.site_config as site_config_mod
 from backend.config.site_config import SiteConfig
 from backend.pipeline.alerts import AlertStore
+from backend.pipeline.clip_extractor import ClipExtractor
 from backend.pipeline.protocol import ChannelPhase, PipelineBackend
 
 router = APIRouter()
@@ -66,6 +67,7 @@ def stop_pipeline(
     request: Request,
     backend: PipelineBackend = Depends(get_backend),
     alert_store: AlertStore = Depends(get_alert_store),
+    clip_extractor: ClipExtractor = Depends(get_clip_extractor),
 ):
     try:
         backend.stop()
@@ -73,6 +75,7 @@ def stop_pipeline(
         raise HTTPException(status_code=409, detail="Pipeline not started")
     request.app.state.pipeline_started = False
     request.app.state.next_channel_id = 0
+    clip_extractor.cleanup_all()
     alert_store.clear()
     request.app.state.ws.enqueue({
         "type": "pipeline_event",
@@ -121,11 +124,13 @@ def remove_channel(
     body: RemoveChannelRequest,
     backend: PipelineBackend = Depends(get_backend),
     alert_store: AlertStore = Depends(get_alert_store),
+    clip_extractor: ClipExtractor = Depends(get_clip_extractor),
 ):
     try:
         backend.remove_channel(body.channel_id)
     except KeyError:
         raise HTTPException(status_code=404, detail="Channel not found")
+    clip_extractor.cleanup_channel(body.channel_id)
     alert_store.clear_channel(body.channel_id)
     return StatusResponse(status="removed")
 
@@ -136,6 +141,8 @@ def set_channel_phase(
     body: SetPhaseRequest,
     request: Request,
     backend: PipelineBackend = Depends(get_backend),
+    alert_store: AlertStore = Depends(get_alert_store),
+    clip_extractor: ClipExtractor = Depends(get_clip_extractor),
 ):
     try:
         phase = ChannelPhase(body.phase)
@@ -149,6 +156,13 @@ def set_channel_phase(
         backend.set_channel_phase(channel_id, phase)
     except KeyError:
         raise HTTPException(status_code=404, detail="Channel not found")
+
+    # Trigger clip extraction on analytics → review transition
+    if previous == ChannelPhase.ANALYTICS and phase == ChannelPhase.REVIEW:
+        source = backend.channels.get(channel_id, "")
+        alerts = alert_store.get_channel_alerts(channel_id)
+        clip_extractor.extract_clips(channel_id, source, alerts)
+
     request.app.state.ws.enqueue({
         "type": "phase_changed",
         "channel": channel_id,
@@ -189,6 +203,46 @@ def get_alert(
     if alert is None:
         raise HTTPException(status_code=404, detail="Alert not found")
     return alert
+
+
+@router.get("/alert/{alert_id}/replay")
+def get_replay(
+    alert_id: str,
+    alert_store: AlertStore = Depends(get_alert_store),
+    clip_extractor: ClipExtractor = Depends(get_clip_extractor),
+):
+    alert = alert_store.get_alert(alert_id)
+    if alert is None:
+        raise HTTPException(status_code=404, detail="Alert not found")
+
+    status = clip_extractor.get_status(alert_id)
+
+    # Clip not yet extracted (phase transition hasn't happened or not started)
+    if status is None:
+        return JSONResponse(
+            status_code=202,
+            content={"status": "not_started", "alert_id": alert_id},
+        )
+
+    if status == "pending":
+        return JSONResponse(
+            status_code=202,
+            content={"status": "extracting", "alert_id": alert_id},
+        )
+
+    if status == "failed":
+        raise HTTPException(status_code=500, detail="Clip extraction failed")
+
+    # status == "ready"
+    clip_path = clip_extractor.get_clip_path(alert_id)
+    if clip_path is None or not clip_path.exists():
+        raise HTTPException(status_code=500, detail="Clip file not found")
+
+    if alert["type"] == "stagnant_alert":
+        return FileResponse(clip_path, media_type="image/jpeg")
+
+    # Transit alert — return video with range request support
+    return FileResponse(clip_path, media_type="video/mp4")
 
 
 @router.get("/snapshot/{track_id}")

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,6 +12,7 @@ from backend.api.routes import router
 from backend.api.websocket import WsBroadcaster
 from backend.api.websocket import router as ws_router
 from backend.pipeline.alerts import AlertStore
+from backend.pipeline.clip_extractor import ClipExtractor
 from backend.pipeline.protocol import FrameResult
 
 
@@ -20,8 +21,10 @@ async def lifespan(app: FastAPI):
     # Startup: start WS broadcaster drain loop
     await app.state.ws.start()
     yield
-    # Shutdown: stop WS broadcaster and pipeline
+    # Shutdown: stop WS broadcaster, clip extractor, and pipeline
     await app.state.ws.stop()
+    app.state.clip_extractor.shutdown()
+    app.state.clip_extractor.cleanup_all()
     if app.state.pipeline_started:
         app.state.backend.stop()
 
@@ -51,6 +54,7 @@ def create_app(backend: str = "deepstream") -> FastAPI:
     )
     app.state.backend = pipeline_backend
     app.state.alert_store = AlertStore()
+    app.state.clip_extractor = ClipExtractor()
     app.state.pipeline_started = False
     app.state.next_channel_id = 0
 

--- a/backend/pipeline/alerts.py
+++ b/backend/pipeline/alerts.py
@@ -156,6 +156,10 @@ class AlertStore:
             return None
         return self._to_summary(alert)
 
+    def get_channel_alerts(self, channel: int) -> list[dict]:
+        """Get all full alert metadata for a channel (for clip extraction)."""
+        return [a for a in self._alerts.values() if a["channel"] == channel]
+
     def count_by_channel(self, channel: int) -> int:
         """Count alerts for a specific channel."""
         return sum(1 for a in self._alerts.values() if a["channel"] == channel)

--- a/backend/pipeline/clip_extractor.py
+++ b/backend/pipeline/clip_extractor.py
@@ -1,0 +1,172 @@
+"""Background clip extraction for transit alert replay.
+
+Extracts short video clips per transit alert using ffmpeg (NVENC when available,
+software fallback otherwise). Stagnant alerts get a single-frame JPEG with bbox overlay.
+"""
+
+import logging
+import shutil
+import subprocess
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+CLIPS_DIR = Path("/tmp/vt_clips")
+PADDING_S = 1.0  # seconds of padding before/after track
+
+
+class ClipExtractor:
+    """Manages clip extraction for replay.
+
+    Thread-safe: extraction runs in a background thread pool.
+    Status per alert_id: "pending", "ready", "failed".
+    """
+
+    def __init__(self, fps: float = 30.0):
+        self._fps = fps
+        self._status: dict[str, str] = {}  # alert_id -> status
+        self._clip_paths: dict[str, Path] = {}  # alert_id -> file path
+        self._pool = ThreadPoolExecutor(max_workers=2, thread_name_prefix="clip")
+
+    def extract_clips(
+        self,
+        channel_id: int,
+        source: str,
+        alerts: list[dict],
+    ) -> None:
+        """Start background extraction for all alerts in a channel.
+
+        Args:
+            channel_id: Channel ID (used for temp directory).
+            source: Video source file path.
+            alerts: List of full alert dicts from AlertStore.
+        """
+        clip_dir = CLIPS_DIR / str(channel_id)
+        clip_dir.mkdir(parents=True, exist_ok=True)
+
+        for alert in alerts:
+            alert_id = alert["alert_id"]
+            alert_type = alert["type"]
+
+            if alert_type == "transit_alert":
+                self._status[alert_id] = "pending"
+                self._pool.submit(
+                    self._extract_transit_clip,
+                    alert_id, source, alert, clip_dir,
+                )
+            elif alert_type == "stagnant_alert":
+                self._status[alert_id] = "pending"
+                self._pool.submit(
+                    self._extract_stagnant_frame,
+                    alert_id, source, alert, clip_dir,
+                )
+
+    def _extract_transit_clip(
+        self, alert_id: str, source: str, alert: dict, clip_dir: Path,
+    ) -> None:
+        """Extract a short clip for a transit alert using ffmpeg."""
+        first_frame = alert.get("first_seen_frame", 0)
+        last_frame = alert.get("last_seen_frame", 0)
+
+        start_s = max(0, first_frame / self._fps - PADDING_S)
+        end_s = last_frame / self._fps + PADDING_S
+
+        output = clip_dir / f"clip_{alert_id}.mp4"
+
+        # Try NVENC first, fall back to libx264
+        for codec in ("h264_nvenc", "libx264"):
+            cmd = [
+                "ffmpeg", "-y",
+                "-ss", f"{start_s:.3f}",
+                "-to", f"{end_s:.3f}",
+                "-i", source,
+                "-c:v", codec,
+                "-an",  # no audio
+                "-loglevel", "error",
+                str(output),
+            ]
+            try:
+                subprocess.run(cmd, check=True, timeout=30)
+                self._clip_paths[alert_id] = output
+                self._status[alert_id] = "ready"
+                logger.info("Clip ready: %s (%s)", alert_id, codec)
+                return
+            except (subprocess.CalledProcessError, FileNotFoundError):
+                if codec == "h264_nvenc":
+                    logger.debug("NVENC unavailable, falling back to libx264")
+                    continue
+                logger.warning("Clip extraction failed for %s", alert_id)
+            except subprocess.TimeoutExpired:
+                logger.warning("Clip extraction timed out for %s", alert_id)
+
+        self._status[alert_id] = "failed"
+
+    def _extract_stagnant_frame(
+        self, alert_id: str, source: str, alert: dict, clip_dir: Path,
+    ) -> None:
+        """Extract a single frame for a stagnant alert using ffmpeg."""
+        # Use the midpoint between first and last seen
+        first_frame = alert.get("first_seen_frame", 0)
+        last_frame = alert.get("last_seen_frame", first_frame)
+        mid_frame = (first_frame + last_frame) // 2
+        timestamp_s = mid_frame / self._fps
+
+        output = clip_dir / f"frame_{alert_id}.jpg"
+
+        cmd = [
+            "ffmpeg", "-y",
+            "-ss", f"{timestamp_s:.3f}",
+            "-i", source,
+            "-frames:v", "1",
+            "-q:v", "2",
+            "-loglevel", "error",
+            str(output),
+        ]
+        try:
+            subprocess.run(cmd, check=True, timeout=10)
+            self._clip_paths[alert_id] = output
+            self._status[alert_id] = "ready"
+            logger.info("Stagnant frame ready: %s", alert_id)
+        except (subprocess.CalledProcessError, FileNotFoundError,
+                subprocess.TimeoutExpired):
+            logger.warning("Stagnant frame extraction failed for %s", alert_id)
+            self._status[alert_id] = "failed"
+
+    def get_status(self, alert_id: str) -> str | None:
+        """Get extraction status: 'pending', 'ready', 'failed', or None."""
+        return self._status.get(alert_id)
+
+    def get_clip_path(self, alert_id: str) -> Path | None:
+        """Get path to extracted clip/frame, or None if not ready."""
+        if self._status.get(alert_id) != "ready":
+            return None
+        return self._clip_paths.get(alert_id)
+
+    def cleanup_channel(self, channel_id: int) -> None:
+        """Remove all clips for a channel and clear status tracking."""
+        clip_dir = CLIPS_DIR / str(channel_id)
+        if clip_dir.exists():
+            shutil.rmtree(clip_dir, ignore_errors=True)
+            logger.info("Cleaned up clips for channel %d", channel_id)
+
+        # Clear status entries for this channel's alerts
+        # (caller should clear alert store separately)
+        to_remove = [
+            aid for aid, path in self._clip_paths.items()
+            if str(channel_id) in str(path)
+        ]
+        for aid in to_remove:
+            self._status.pop(aid, None)
+            self._clip_paths.pop(aid, None)
+
+    def cleanup_all(self) -> None:
+        """Remove all clips and reset state."""
+        if CLIPS_DIR.exists():
+            shutil.rmtree(CLIPS_DIR, ignore_errors=True)
+        self._status.clear()
+        self._clip_paths.clear()
+
+    def shutdown(self) -> None:
+        """Shutdown the thread pool."""
+        self._pool.shutdown(wait=False)

--- a/backend/tests/test_m3_phase6.py
+++ b/backend/tests/test_m3_phase6.py
@@ -1,0 +1,178 @@
+"""Tests for M3 Phase 6: Replay backend — clip extraction + replay endpoint."""
+
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+TRANSIT_ALERT = {
+    "track_id": 10,
+    "label": "car",
+    "entry_arm": "north",
+    "entry_label": "741-North",
+    "exit_arm": "south",
+    "exit_label": "741-South",
+    "method": "confirmed",
+    "was_stagnant": False,
+    "first_seen_frame": 100,
+    "last_seen_frame": 400,
+    "duration_frames": 300,
+    "trajectory": [(100, 200), (150, 250)],
+    "per_frame_data": [
+        {"frame": 100, "bbox": (10, 20, 30, 40), "centroid": (25, 40),
+         "confidence": 0.9, "timestamp_ms": 3333},
+        {"frame": 400, "bbox": (50, 60, 30, 40), "centroid": (65, 80),
+         "confidence": 0.85, "timestamp_ms": 13333},
+    ],
+}
+
+STAGNANT_ALERT = {
+    "track_id": 20,
+    "label": "truck",
+    "position": (450, 320),
+    "stationary_duration_frames": 4500,
+    "first_seen_frame": 0,
+    "last_seen_frame": 4500,
+}
+
+
+@pytest.fixture
+def started_client(client):
+    """Client with pipeline started and one channel added."""
+    client.post("/pipeline/start")
+    client.post("/channel/add", json={"source": "/data/video.mp4"})
+    return client
+
+
+@pytest.fixture
+def seeded_alerts(app):
+    """AlertStore with transit + stagnant alerts on channel 0."""
+    store = app.state.alert_store
+    t_id = store.add_transit_alert(TRANSIT_ALERT, channel=0)
+    s_id = store.add_stagnant_alert(STAGNANT_ALERT, channel=0)
+    return t_id, s_id
+
+
+# -- ClipExtractor unit tests --
+
+class TestClipExtractor:
+    def test_initial_status_none(self, app):
+        extractor = app.state.clip_extractor
+        assert extractor.get_status("nonexistent") is None
+
+    def test_get_clip_path_none_when_not_ready(self, app):
+        extractor = app.state.clip_extractor
+        assert extractor.get_clip_path("nonexistent") is None
+
+    def test_cleanup_channel_no_error_when_empty(self, app):
+        extractor = app.state.clip_extractor
+        extractor.cleanup_channel(99)  # should not raise
+
+    def test_cleanup_all(self, app):
+        extractor = app.state.clip_extractor
+        extractor._status["test"] = "ready"
+        extractor._clip_paths["test"] = Path("/tmp/test.mp4")
+        extractor.cleanup_all()
+        assert extractor.get_status("test") is None
+        assert extractor.get_clip_path("test") is None
+
+
+# -- AlertStore.get_channel_alerts --
+
+class TestGetChannelAlerts:
+    def test_returns_full_alerts(self, app, seeded_alerts):
+        store = app.state.alert_store
+        alerts = store.get_channel_alerts(0)
+        assert len(alerts) == 2
+        # Full alerts include per_frame_data
+        transit = next(a for a in alerts if a["type"] == "transit_alert")
+        assert "per_frame_data" in transit
+
+    def test_empty_channel(self, app):
+        store = app.state.alert_store
+        assert store.get_channel_alerts(99) == []
+
+
+# -- Replay endpoint --
+
+class TestReplayEndpoint:
+    def test_alert_not_found(self, client):
+        resp = client.get("/alert/nonexistent/replay")
+        assert resp.status_code == 404
+
+    def test_202_when_not_started(self, started_client, seeded_alerts):
+        t_id, _ = seeded_alerts
+        resp = started_client.get(f"/alert/{t_id}/replay")
+        assert resp.status_code == 202
+        assert resp.json()["status"] == "not_started"
+
+    def test_202_when_pending(self, started_client, app, seeded_alerts):
+        t_id, _ = seeded_alerts
+        app.state.clip_extractor._status[t_id] = "pending"
+        resp = started_client.get(f"/alert/{t_id}/replay")
+        assert resp.status_code == 202
+        assert resp.json()["status"] == "extracting"
+
+    def test_500_when_failed(self, started_client, app, seeded_alerts):
+        t_id, _ = seeded_alerts
+        app.state.clip_extractor._status[t_id] = "failed"
+        resp = started_client.get(f"/alert/{t_id}/replay")
+        assert resp.status_code == 500
+
+    def test_200_transit_clip_ready(self, started_client, app, seeded_alerts, tmp_path):
+        t_id, _ = seeded_alerts
+        # Create a fake clip file
+        clip = tmp_path / f"clip_{t_id}.mp4"
+        clip.write_bytes(b"\x00\x00\x00\x1cftyp")  # minimal mp4 header
+        app.state.clip_extractor._status[t_id] = "ready"
+        app.state.clip_extractor._clip_paths[t_id] = clip
+        resp = started_client.get(f"/alert/{t_id}/replay")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "video/mp4"
+
+    def test_200_stagnant_frame_ready(self, started_client, app, seeded_alerts, tmp_path):
+        _, s_id = seeded_alerts
+        frame = tmp_path / f"frame_{s_id}.jpg"
+        frame.write_bytes(b"\xff\xd8\xff\xe0")  # minimal JPEG header
+        app.state.clip_extractor._status[s_id] = "ready"
+        app.state.clip_extractor._clip_paths[s_id] = frame
+        resp = started_client.get(f"/alert/{s_id}/replay")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "image/jpeg"
+
+
+# -- Phase transition triggers clip extraction --
+
+class TestPhaseTransitionClipExtraction:
+    def test_analytics_to_review_triggers_extraction(self, started_client, app, seeded_alerts):
+        # Move to analytics first
+        started_client.post("/channel/0/phase", json={"phase": "analytics"})
+
+        with patch.object(app.state.clip_extractor, "extract_clips") as mock:
+            started_client.post("/channel/0/phase", json={"phase": "review"})
+            mock.assert_called_once()
+            args = mock.call_args
+            assert args[0][0] == 0  # channel_id
+            assert args[0][1] == "/data/video.mp4"  # source
+            assert len(args[0][2]) == 2  # 2 alerts
+
+    def test_setup_to_analytics_no_extraction(self, started_client, app):
+        with patch.object(app.state.clip_extractor, "extract_clips") as mock:
+            started_client.post("/channel/0/phase", json={"phase": "analytics"})
+            mock.assert_not_called()
+
+
+# -- Cleanup on channel remove --
+
+class TestCleanupOnRemove:
+    def test_channel_remove_cleans_clips(self, started_client, app):
+        with patch.object(app.state.clip_extractor, "cleanup_channel") as mock:
+            started_client.post("/channel/remove", json={"channel_id": 0})
+            mock.assert_called_once_with(0)
+
+    def test_pipeline_stop_cleans_all_clips(self, started_client, app):
+        with patch.object(app.state.clip_extractor, "cleanup_all") as mock:
+            started_client.post("/pipeline/stop")
+            mock.assert_called_once()


### PR DESCRIPTION
## Summary
- **ClipExtractor** module: background thread pool for ffmpeg clip extraction, NVENC with libx264 fallback, per-alert status tracking (pending/ready/failed)
- **Transit clips**: short video segments with 1s padding around track duration, extracted on analytics→review transition
- **Stagnant frames**: single JPEG frame at midpoint of stationary period
- **`GET /alert/{id}/replay`**: returns video/mp4 (transit) or image/jpeg (stagnant) with 200, 202 when extracting, 404/500 for errors
- **Phase transition hook**: analytics→review triggers `extract_clips()` for all channel alerts
- **Cleanup**: clips removed on channel remove (`cleanup_channel`) and pipeline stop (`cleanup_all`)
- **`AlertStore.get_channel_alerts()`**: new method for bulk full-alert retrieval
- 16 new tests, 286 total passing

Closes #35

## Test plan
- [ ] ClipExtractor status tracking: initial None, pending, ready, failed
- [ ] Replay endpoint: 404 for missing alert, 202 when not started/pending, 500 when failed
- [ ] Replay endpoint: 200 with video/mp4 for transit, image/jpeg for stagnant
- [ ] Phase transition: analytics→review triggers extraction, setup→analytics does not
- [ ] Channel remove cleans up clips
- [ ] Pipeline stop cleans up all clips
- [ ] `./dev.sh exec backend pytest backend/tests/ -v` — 286 tests pass