### PR TITLE
M3 Phase 7: Review phase — replay UI + clickable alert feed

### DIFF
--- a/frontend/src/api/rest.js
+++ b/frontend/src/api/rest.js
@@ -85,6 +85,19 @@ export async function getAlert(alertId) {
   return (await request(`/alert/${alertId}`)).json();
 }
 
+// -- Replay --
+
+export function replayUrl(alertId) {
+  return `/api/alert/${alertId}/replay`;
+}
+
+export async function getReplayStatus(alertId) {
+  const resp = await fetch(`${BASE}/alert/${alertId}/replay`);
+  if (resp.status === 202) return { status: (await resp.json()).status };
+  if (resp.status === 200) return { status: "ready" };
+  throw new Error(`Replay error: ${resp.status}`);
+}
+
 // -- Snapshots --
 
 export function snapshotUrl(trackId) {

--- a/frontend/src/components/AlertFeed.jsx
+++ b/frontend/src/components/AlertFeed.jsx
@@ -4,6 +4,7 @@ import { useAlerts } from "../contexts/AlertContext";
 import { snapshotUrl } from "../api/rest";
 
 const CARD_HEIGHT = 76; // px per alert card
+const EXPANDED_HEIGHT = 340; // px for expanded card with detail
 const FILTERS = [
   { key: "all", label: "All" },
   { key: "transit_alert", label: "Transit" },
@@ -22,34 +23,40 @@ function formatRelativeTime(timestamp) {
   return `${Math.floor(diff / 86400)}d ago`;
 }
 
-function AlertCard({ alert }) {
+function AlertCard({ alert, isReview, isSelected, onSelect }) {
   const isTransit = alert.type === "transit_alert";
   const dotColor = isTransit ? "bg-transit-blue" : "bg-stagnant-amber";
   const textColor = isTransit ? "text-transit-blue" : "text-stagnant-amber";
+  const borderColor = isTransit ? "border-l-transit-blue" : "border-l-stagnant-amber";
+  const bgColor = isTransit ? "bg-transit-blue/5" : "bg-stagnant-amber/5";
 
   let directionLabel = "Stagnant";
   if (isTransit) {
     const entry = alert.entry_arm || alert.entry_label || "?";
     const exit = alert.exit_arm || alert.exit_label || "?";
-    // Use short arm names (first letter uppercase)
     const e = entry.charAt(0).toUpperCase();
     const x = exit.charAt(0).toUpperCase();
     directionLabel = `${e} \u21A3 ${x}`;
   }
 
-  const label = alert.label || "vehicle";
+  const label = alert.label || alert.class || "vehicle";
   const trackId = alert.track_id ?? "?";
   const duration = alert.duration_frames
     ? `${(alert.duration_frames / 30).toFixed(1)}s`
     : isTransit
-      ? ""
+      ? alert.duration_ms ? `${(alert.duration_ms / 1000).toFixed(1)}s` : ""
       : alert.stationary_duration_frames
         ? `${(alert.stationary_duration_frames / 30).toFixed(0)}s`
-        : "";
+        : alert.stationary_duration_ms ? `${(alert.stationary_duration_ms / 1000).toFixed(0)}s` : "";
   const method = alert.method || "";
 
   return (
-    <div className="px-3 py-2.5 border-b border-border/50 cursor-default">
+    <div
+      className={`px-3 py-2.5 border-b border-border/50 ${
+        isSelected ? `${bgColor} border-l-2 ${borderColor}` : ""
+      } ${isReview ? "cursor-pointer hover:bg-background/50 transition-colors" : "cursor-default"}`}
+      onClick={() => isReview && onSelect?.(alert)}
+    >
       <div className="flex gap-3">
         {/* Thumbnail */}
         <div className="w-16 h-16 rounded-lg bg-background flex-shrink-0 overflow-hidden">
@@ -71,7 +78,7 @@ function AlertCard({ alert }) {
             <span className={`w-1.5 h-1.5 rounded-full ${dotColor}`} />
             <span className={`text-xs font-medium ${textColor}`}>{directionLabel}</span>
             <span className="text-[10px] text-text-muted ml-auto">
-              {formatRelativeTime(alert.timestamp)}
+              {formatRelativeTime(alert.timestamp || alert.timestamp_ms)}
             </span>
           </div>
           <div className="text-xs text-text-secondary truncate">
@@ -87,12 +94,103 @@ function AlertCard({ alert }) {
   );
 }
 
-export default function AlertFeed({ alertCount }) {
+function AlertDetail({ alert }) {
+  const isTransit = alert.type === "transit_alert";
+
+  return (
+    <div className="px-3 pb-3 space-y-3">
+      {/* Best photo */}
+      <div className="w-full aspect-video rounded-lg bg-background overflow-hidden">
+        {alert.track_id != null ? (
+          <img
+            src={snapshotUrl(alert.track_id)}
+            alt="Best photo"
+            className="w-full h-full object-cover"
+            onError={(e) => { e.target.style.display = "none"; }}
+          />
+        ) : (
+          <div className="w-full h-full bg-gradient-to-br from-zinc-700 to-zinc-800 flex items-center justify-center">
+            <span className="text-text-muted text-xs">No photo</span>
+          </div>
+        )}
+      </div>
+
+      {/* Metadata grid */}
+      <div className="grid grid-cols-2 gap-x-4 gap-y-1.5 text-xs">
+        <div>
+          <span className="text-text-muted">Track ID</span>
+          <p className="text-text-primary">#{alert.track_id ?? "?"}</p>
+        </div>
+        <div>
+          <span className="text-text-muted">Class</span>
+          <p className="text-text-primary">{alert.class || alert.label || "unknown"}</p>
+        </div>
+        {isTransit ? (
+          <>
+            <div>
+              <span className="text-text-muted">Direction</span>
+              <p className="text-text-primary">
+                {alert.entry_direction || alert.entry_arm || "?"} → {alert.exit_direction || alert.exit_arm || "?"}
+              </p>
+            </div>
+            <div>
+              <span className="text-text-muted">Duration</span>
+              <p className="text-text-primary">
+                {alert.duration_ms ? `${(alert.duration_ms / 1000).toFixed(1)}s` : "—"}
+              </p>
+            </div>
+            <div>
+              <span className="text-text-muted">Method</span>
+              <p className="text-text-primary">{alert.method || "—"}</p>
+            </div>
+            <div>
+              <span className="text-text-muted">Confidence</span>
+              <p className="text-text-primary">
+                {alert.avg_confidence != null ? alert.avg_confidence.toFixed(2) : "—"}
+              </p>
+            </div>
+          </>
+        ) : (
+          <>
+            <div>
+              <span className="text-text-muted">Duration</span>
+              <p className="text-text-primary">
+                {alert.stationary_duration_ms
+                  ? `${Math.floor(alert.stationary_duration_ms / 1000)}s`
+                  : "—"}
+              </p>
+            </div>
+            <div>
+              <span className="text-text-muted">Position</span>
+              <p className="text-text-primary">
+                {alert.position ? `(${alert.position[0]}, ${alert.position[1]})` : "—"}
+              </p>
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* Download button */}
+      {alert.track_id != null && (
+        <a
+          href={snapshotUrl(alert.track_id)}
+          download={`track_${alert.track_id}.jpg`}
+          className="block w-full px-3 py-2 bg-background border border-border rounded-lg text-xs text-text-secondary hover:text-text-primary hover:border-border-strong transition-colors text-center"
+        >
+          Download Photo
+        </a>
+      )}
+    </div>
+  );
+}
+
+export default function AlertFeed({ phase, selectedAlertId, onSelectAlert }) {
   const { state, dispatch } = useAlerts();
   const parentRef = useRef(null);
   const [newCount, setNewCount] = useState(0);
   const [atTop, setAtTop] = useState(true);
   const prevLenRef = useRef(state.alerts.length);
+  const isReview = phase === "review";
 
   // Filtered alerts
   const filtered = useMemo(() => {
@@ -104,9 +202,20 @@ export default function AlertFeed({ alertCount }) {
   const virtualizer = useVirtualizer({
     count: filtered.length,
     getScrollElement: () => parentRef.current,
-    estimateSize: () => CARD_HEIGHT,
+    estimateSize: (index) => {
+      const alert = filtered[index];
+      if (isReview && alert && alert.alert_id === selectedAlertId) {
+        return CARD_HEIGHT + EXPANDED_HEIGHT;
+      }
+      return CARD_HEIGHT;
+    },
     overscan: 10,
   });
+
+  // Re-measure when selection changes
+  useEffect(() => {
+    virtualizer.measure();
+  }, [selectedAlertId, virtualizer]);
 
   // Track if user is at top of scroll
   const handleScroll = useCallback(() => {
@@ -125,7 +234,6 @@ export default function AlertFeed({ alertCount }) {
 
     if (len > prevLen) {
       if (atTop) {
-        // Already at top — scroll stays at top (prepend)
         setNewCount(0);
       } else {
         setNewCount((c) => c + (len - prevLen));
@@ -183,7 +291,9 @@ export default function AlertFeed({ alertCount }) {
       >
         {filtered.length === 0 ? (
           <div className="flex items-center justify-center h-full">
-            <p className="text-text-muted text-xs">Waiting for alerts...</p>
+            <p className="text-text-muted text-xs">
+              {isReview ? "No alerts to review" : "Waiting for alerts..."}
+            </p>
           </div>
         ) : (
           <div
@@ -195,6 +305,7 @@ export default function AlertFeed({ alertCount }) {
           >
             {virtualizer.getVirtualItems().map((virtualRow) => {
               const alert = filtered[virtualRow.index];
+              const isSelected = isReview && alert.alert_id === selectedAlertId;
               return (
                 <div
                   key={alert.alert_id || virtualRow.index}
@@ -207,7 +318,13 @@ export default function AlertFeed({ alertCount }) {
                     transform: `translateY(${virtualRow.start}px)`,
                   }}
                 >
-                  <AlertCard alert={alert} />
+                  <AlertCard
+                    alert={alert}
+                    isReview={isReview}
+                    isSelected={isSelected}
+                    onSelect={onSelectAlert}
+                  />
+                  {isSelected && <AlertDetail alert={alert} />}
                 </div>
               );
             })}

--- a/frontend/src/components/ReplayView.jsx
+++ b/frontend/src/components/ReplayView.jsx
@@ -1,0 +1,237 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getAlert, replayUrl, getReplayStatus } from "../api/rest";
+
+const TRANSIT_COLOR = "#60a5fa";
+const STAGNANT_COLOR = "#fbbf24";
+const ENTRY_COLOR = "#4ade80";
+const LABEL_BG = "rgba(0,0,0,0.7)";
+
+/**
+ * ReplayView — replaces MJPEG video panel in Review phase.
+ *
+ * Props:
+ *   alert - selected alert summary (from AlertFeed click)
+ */
+export default function ReplayView({ alert }) {
+  const [fullAlert, setFullAlert] = useState(null);
+  const [replayStatus, setReplayStatus] = useState(null);
+  const [error, setError] = useState(null);
+  const videoRef = useRef(null);
+  const canvasRef = useRef(null);
+  const containerRef = useRef(null);
+
+  // Fetch full alert data + replay status
+  useEffect(() => {
+    if (!alert) return;
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const [full, status] = await Promise.all([
+          getAlert(alert.alert_id),
+          getReplayStatus(alert.alert_id),
+        ]);
+        if (cancelled) return;
+        setFullAlert(full);
+        setReplayStatus(status.status);
+        setError(null);
+      } catch {
+        if (!cancelled) setError("Failed to load replay");
+      }
+    }
+    load();
+
+    // Poll if extracting
+    let pollTimer;
+    if (replayStatus === "extracting" || replayStatus === "not_started") {
+      pollTimer = setInterval(async () => {
+        try {
+          const s = await getReplayStatus(alert.alert_id);
+          if (!cancelled) setReplayStatus(s.status);
+        } catch { /* ignore */ }
+      }, 2000);
+    }
+
+    return () => {
+      cancelled = true;
+      clearInterval(pollTimer);
+    };
+  }, [alert?.alert_id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Canvas overlay for bbox + trajectory (transit clips)
+  const drawOverlay = useCallback(() => {
+    const canvas = canvasRef.current;
+    const video = videoRef.current;
+    if (!canvas || !video || !fullAlert) return;
+
+    const ctx = canvas.getContext("2d");
+    const container = containerRef.current;
+    if (!container) return;
+
+    canvas.width = container.clientWidth;
+    canvas.height = container.clientHeight;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    const perFrame = fullAlert.per_frame_data || [];
+    if (perFrame.length === 0) return;
+
+    // Get current video time and find matching frame
+    const currentMs = (video.currentTime || 0) * 1000;
+    const firstTs = perFrame[0].timestamp_ms;
+    const adjustedMs = currentMs + firstTs; // clip starts at first_seen - padding
+
+    // Binary search for closest frame
+    let lo = 0, hi = perFrame.length - 1;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (perFrame[mid].timestamp_ms < adjustedMs) lo = mid + 1;
+      else hi = mid;
+    }
+    const frame = perFrame[lo];
+    if (!frame) return;
+
+    // Scale factor (video natural size → canvas display size)
+    const natW = video.videoWidth || 1920;
+    const natH = video.videoHeight || 1080;
+    const sx = canvas.width / natW;
+    const sy = canvas.height / natH;
+
+    const color = TRANSIT_COLOR;
+
+    // Draw trajectory trail
+    const trajectory = fullAlert.full_trajectory || [];
+    if (trajectory.length >= 2) {
+      ctx.beginPath();
+      ctx.moveTo(trajectory[0][0] * sx, trajectory[0][1] * sy);
+      for (let i = 1; i < trajectory.length; i++) {
+        ctx.lineTo(trajectory[i][0] * sx, trajectory[i][1] * sy);
+      }
+      ctx.strokeStyle = color;
+      ctx.lineWidth = 1.5;
+      ctx.setLineDash([4, 3]);
+      ctx.globalAlpha = 0.5;
+      ctx.stroke();
+      ctx.setLineDash([]);
+      ctx.globalAlpha = 1;
+
+      // Entry point
+      const entry = trajectory[0];
+      ctx.beginPath();
+      ctx.arc(entry[0] * sx, entry[1] * sy, 4, 0, Math.PI * 2);
+      ctx.fillStyle = ENTRY_COLOR;
+      ctx.globalAlpha = 0.7;
+      ctx.fill();
+      ctx.globalAlpha = 1;
+    }
+
+    // Draw bbox
+    const [bx, by, bw, bh] = frame.bbox;
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 2.5;
+    ctx.strokeRect(bx * sx, by * sy, bw * sx, bh * sy);
+  }, [fullAlert]);
+
+  // Video frame callback for sync
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video || !fullAlert || fullAlert.type !== "transit_alert") return;
+
+    let rafId;
+    function onFrame() {
+      drawOverlay();
+      if ("requestVideoFrameCallback" in video) {
+        rafId = video.requestVideoFrameCallback(onFrame);
+      }
+    }
+
+    if ("requestVideoFrameCallback" in video) {
+      rafId = video.requestVideoFrameCallback(onFrame);
+    } else {
+      // Fallback: use requestAnimationFrame
+      function fallback() {
+        drawOverlay();
+        rafId = requestAnimationFrame(fallback);
+      }
+      rafId = requestAnimationFrame(fallback);
+      return () => cancelAnimationFrame(rafId);
+    }
+
+    return () => {
+      if ("cancelVideoFrameCallback" in video) {
+        video.cancelVideoFrameCallback(rafId);
+      }
+    };
+  }, [fullAlert, drawOverlay]);
+
+  if (!alert) {
+    return (
+      <div className="flex-1 bg-black flex items-center justify-center">
+        <div className="text-center">
+          <svg className="w-12 h-12 text-text-muted mx-auto mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <p className="text-text-muted text-sm">Select an alert to view replay</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex-1 bg-black flex items-center justify-center">
+        <p className="text-error-red text-sm">{error}</p>
+      </div>
+    );
+  }
+
+  // Extracting / not ready
+  if (replayStatus === "extracting" || replayStatus === "not_started") {
+    return (
+      <div className="flex-1 bg-black flex items-center justify-center">
+        <div className="text-center">
+          <svg className="w-6 h-6 text-text-muted animate-spin mx-auto mb-3" fill="none" viewBox="0 0 24 24">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+          </svg>
+          <p className="text-text-muted text-sm">Extracting replay clip...</p>
+        </div>
+      </div>
+    );
+  }
+
+  const isTransit = alert.type === "transit_alert";
+  const clipUrl = replayUrl(alert.alert_id);
+
+  // Stagnant alert — static image
+  if (!isTransit) {
+    return (
+      <div className="flex-1 bg-black flex items-center justify-center relative" ref={containerRef}>
+        <img
+          src={clipUrl}
+          alt="Stagnant alert frame"
+          className="max-w-full max-h-full object-contain"
+        />
+      </div>
+    );
+  }
+
+  // Transit alert — looping video with canvas overlay
+  return (
+    <div className="flex-1 bg-black flex items-center justify-center relative" ref={containerRef}>
+      <video
+        ref={videoRef}
+        src={clipUrl}
+        loop
+        autoPlay
+        muted
+        playsInline
+        className="max-w-full max-h-full object-contain"
+      />
+      <canvas
+        ref={canvasRef}
+        className="absolute inset-0 w-full h-full pointer-events-none"
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/Channel.jsx
+++ b/frontend/src/pages/Channel.jsx
@@ -6,6 +6,7 @@ import { useToast } from "../components/Toast";
 import AlertFeed from "../components/AlertFeed";
 import DrawingCanvas from "../components/DrawingCanvas";
 import DrawingTools from "../components/DrawingTools";
+import ReplayView from "../components/ReplayView";
 import StatsBar from "../components/StatsBar";
 import { getChannel, getAlerts, setChannelPhase, updateConfig } from "../api/rest";
 import { createWs } from "../api/ws";
@@ -103,6 +104,9 @@ function ChannelContent() {
   const [error, setError] = useState(null);
   const [pageLoading, setPageLoading] = useState(true);
   const [phaseLoading, setPhaseLoading] = useState(false);
+
+  // Review state
+  const [selectedAlert, setSelectedAlert] = useState(null);
 
   // Drawing state
   const [tool, setTool] = useState(null);
@@ -349,15 +353,19 @@ function ChannelContent() {
 
       {/* Main Content */}
       <div className="flex flex-1 min-h-0">
-        {/* Video Panel */}
+        {/* Video / Replay Panel */}
         <div className="flex-1 flex flex-col min-w-0">
-          <VideoPanel
-            channelId={channelId}
-            pipelineStarted={pipelineStarted}
-            phase={phase}
-            imgRef={imgRef}
-            drawingProps={drawingProps}
-          />
+          {phase === "review" ? (
+            <ReplayView alert={selectedAlert} />
+          ) : (
+            <VideoPanel
+              channelId={channelId}
+              pipelineStarted={pipelineStarted}
+              phase={phase}
+              imgRef={imgRef}
+              drawingProps={drawingProps}
+            />
+          )}
           <StatsBar />
         </div>
 
@@ -381,7 +389,11 @@ function ChannelContent() {
             loading={phaseLoading}
           />
         ) : (
-          <AlertFeed />
+          <AlertFeed
+            phase={phase}
+            selectedAlertId={selectedAlert?.alert_id}
+            onSelectAlert={setSelectedAlert}
+          />
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- **ReplayView** component: transit alert video replay (looping `<video>` + `<canvas>` overlay for bbox/trajectory synced via `requestVideoFrameCallback`), stagnant alert static frame, extracting spinner with 2s polling, "Select an alert" empty state
- **AlertFeed** updated: cards clickable in review phase (cursor-pointer, hover effect), selected card highlighted with accent left border + expanded detail panel (best photo, metadata grid with track ID/class/direction/duration/confidence/method, Download Photo button)
- **Channel.jsx**: shows ReplayView instead of MJPEG VideoPanel in review phase, passes phase/selectedAlert to AlertFeed
- **rest.js**: `replayUrl()` and `getReplayStatus()` helpers for replay endpoint
- 286 backend tests passing

Closes #36

## Test plan
- [ ] Review phase shows "Select an alert to view replay" placeholder
- [ ] Phase indicator highlights "Review" in green
- [ ] Alert feed shows "No alerts to review" when empty
- [ ] Cards are clickable in review (cursor-pointer, hover)
- [ ] Clicking card shows expanded detail with metadata + download button
- [ ] Replay panel shows extracting spinner when clip not ready
- [ ] Transit clip loops with bbox overlay when ready
- [ ] Stagnant alert shows static frame
- [ ] `./dev.sh exec backend pytest backend/tests/ -v` — 286 tests pass