### PR TITLE
M7-P2: MJPEG frame rendering for custom pipeline

### DIFF
--- a/backend/pipeline/custom/adapter.py
+++ b/backend/pipeline/custom/adapter.py
@@ -20,6 +20,7 @@ from backend.pipeline.custom.decoder import NvDecoder
 from backend.pipeline.custom.detector import COCO_VEHICLE_CLASSES, TRTDetector
 from backend.pipeline.custom.engine_builder import ensure_engine
 from backend.pipeline.custom.preprocess import GpuPreprocessor, nv12_to_bgr_gpu
+from backend.pipeline.custom.renderer import FrameRenderer
 from backend.pipeline.custom.tracker import TrackerWrapper
 from backend.pipeline.direction import (
     DirectionStateMachine,
@@ -73,6 +74,7 @@ class CustomPipeline:
         self._states: dict[int, _ChannelState] = {}
         self._detector: TRTDetector | None = None
         self._preprocess = GpuPreprocessor()
+        self._renderer = FrameRenderer()
         self._running = False
         self._thread: threading.Thread | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
@@ -81,6 +83,10 @@ class CustomPipeline:
         self._alert_callback: Callable | None = None
         self._track_ended_callback: Callable | None = None
         self._phase_callback: Callable | None = None
+        # Stats tracking (per-channel, for stats_update broadcasts)
+        self._stats_last_time: dict[int, float] = {}
+        self._stats_frame_count: dict[int, int] = {}
+        self._stats_infer_sum: dict[int, float] = {}
         # Thread-safe transition queue
         self._transition_queue: Queue = Queue()
 
@@ -687,9 +693,21 @@ class CustomPipeline:
         infer_ms: float,
         pts: int,
     ):
-        """Build FrameResult and fire callback."""
-        # For P1, no annotated_jpeg (that's P2 — renderer)
-        # Build detection list
+        """Render annotated frame, build FrameResult, fire callback."""
+        # Render annotated JPEG
+        annotated_jpeg = self._renderer.render(
+            nv12,
+            state.decoder.height,
+            state.decoder.width,
+            tracks,
+            state.phase,
+            state.roi_polygon,
+            state.entry_exit_lines,
+        )
+
+        # Save as last frame for Phase 3 replay
+        state.last_frame_jpeg = annotated_jpeg
+
         det_list = [
             Detection(
                 track_id=t["track_id"],
@@ -706,7 +724,7 @@ class CustomPipeline:
             frame_number=state.infer_count,
             timestamp_ms=pts,
             detections=det_list,
-            annotated_jpeg=None,  # P2
+            annotated_jpeg=annotated_jpeg,
             inference_ms=infer_ms,
             phase=state.phase.value,
         )

--- a/backend/pipeline/custom/renderer.py
+++ b/backend/pipeline/custom/renderer.py
@@ -1,0 +1,108 @@
+"""Frame renderer — bbox drawing + JPEG encoding for MJPEG output.
+
+Downloads NV12 GPU frame to CPU, draws bounding boxes and track IDs,
+optionally draws ROI polygon and entry/exit lines, encodes to JPEG.
+"""
+
+import cv2
+import cupy as cp
+import numpy as np
+
+from backend.pipeline.custom.preprocess import nv12_to_bgr_gpu
+from backend.pipeline.protocol import ChannelPhase
+
+# Colors (BGR)
+_GREEN = (0, 255, 0)
+_WHITE = (255, 255, 255)
+_CYAN = (255, 255, 0)
+_YELLOW = (0, 255, 255)
+_RED = (0, 0, 255)
+_BOX_THICKNESS = 2
+_FONT = cv2.FONT_HERSHEY_SIMPLEX
+_FONT_SCALE = 0.5
+_FONT_THICKNESS = 1
+_JPEG_QUALITY = 80
+
+
+class FrameRenderer:
+    """Renders annotated frames for MJPEG output."""
+
+    def render(
+        self,
+        nv12_frame: cp.ndarray,
+        height: int,
+        width: int,
+        tracks: list[dict],
+        phase: ChannelPhase,
+        roi_polygon: list[tuple[float, float]] | None = None,
+        entry_exit_lines: dict | None = None,
+    ) -> bytes:
+        """Download frame, draw annotations, encode JPEG.
+
+        Returns: JPEG bytes.
+        """
+        # NV12 → BGR on GPU, then download to CPU
+        bgr_gpu = nv12_to_bgr_gpu(nv12_frame, height, width)
+        frame = cp.asnumpy(bgr_gpu)
+
+        # Draw bounding boxes and track IDs
+        for track in tracks:
+            x, y, w, h = track["bbox"]
+            tid = track["track_id"]
+            conf = track["confidence"]
+            label = track.get("class_name", "")
+
+            cv2.rectangle(frame, (x, y), (x + w, y + h), _GREEN, _BOX_THICKNESS)
+            text = f"#{tid} {label} {conf:.2f}"
+            cv2.putText(
+                frame, text, (x, y - 8),
+                _FONT, _FONT_SCALE, _GREEN, _FONT_THICKNESS,
+            )
+
+        # Draw ROI polygon (Setup + Analytics)
+        if roi_polygon and len(roi_polygon) >= 3:
+            pts = np.array(roi_polygon, dtype=np.int32).reshape((-1, 1, 2))
+            cv2.polylines(frame, [pts], isClosed=True, color=_CYAN, thickness=1)
+
+        # Draw entry/exit lines
+        if entry_exit_lines:
+            for arm_id, line_data in entry_exit_lines.items():
+                if isinstance(line_data, dict):
+                    start = tuple(int(v) for v in line_data["start"])
+                    end = tuple(int(v) for v in line_data["end"])
+                    lbl = line_data.get("label", arm_id)
+                else:
+                    start = (int(line_data.start[0]), int(line_data.start[1]))
+                    end = (int(line_data.end[0]), int(line_data.end[1]))
+                    lbl = line_data.label
+                cv2.line(frame, start, end, _YELLOW, 2)
+                mid = ((start[0] + end[0]) // 2, (start[1] + end[1]) // 2)
+                cv2.putText(
+                    frame, lbl, (mid[0] - 20, mid[1] - 10),
+                    _FONT, 0.4, _YELLOW, 1,
+                )
+
+        # Encode JPEG
+        _, jpeg = cv2.imencode(
+            ".jpg", frame, [cv2.IMWRITE_JPEG_QUALITY, _JPEG_QUALITY],
+        )
+        return jpeg.tobytes()
+
+    def render_cpu_frame(
+        self,
+        frame: np.ndarray,
+        tracks: list[dict],
+    ) -> bytes:
+        """Render on an already-downloaded CPU BGR frame. For best-photo crops."""
+        for track in tracks:
+            x, y, w, h = track["bbox"]
+            tid = track["track_id"]
+            cv2.rectangle(frame, (x, y), (x + w, y + h), _GREEN, _BOX_THICKNESS)
+            cv2.putText(
+                frame, f"#{tid}", (x, y - 8),
+                _FONT, _FONT_SCALE, _GREEN, _FONT_THICKNESS,
+            )
+        _, jpeg = cv2.imencode(
+            ".jpg", frame, [cv2.IMWRITE_JPEG_QUALITY, _JPEG_QUALITY],
+        )
+        return jpeg.tobytes()


### PR DESCRIPTION
## Summary

- `renderer.py`: NV12→BGR GPU conversion, CPU bbox drawing, JPEG encoding
- Wired into adapter frame emission at ~15fps
- ROI polygon and entry/exit line overlays rendered
- Last frame saved for Phase 3 replay

## Test plan

- [x] All 363 existing tests pass
- [x] JPEG frames produced with correct bounding boxes (verified visually)
- [x] 298KB JPEG at 1080p q=80
- [ ] MJPEG stream visible in browser via `GET /stream/{channel_id}`

Closes #98