### PR TITLE
Fix custom-backend playback pacing and clip-extractor race

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ CLAUDE.md
 .node-cache
 .training-cache
 .pytest_cache
+.playwright-mcp/

--- a/backend/pipeline/clip_extractor.py
+++ b/backend/pipeline/clip_extractor.py
@@ -2,13 +2,19 @@
 
 Extracts short video clips per transit alert using ffmpeg (NVENC when available,
 software fallback otherwise). Stagnant alerts get a single-frame JPEG with bbox overlay.
+
+Cleanup is race-free: futures are tracked per channel so `cleanup_channel` can
+drain in-flight ffmpeg jobs before `rmtree`-ing the output directory. Without
+this, jobs writing to `/tmp/vt_clips/<id>/` would fail with ENOENT mid-write
+when `/channel/remove` (or `/pipeline/stop`) deletes the directory.
 """
 
 import logging
 import shutil
 import subprocess
 import threading
-from concurrent.futures import ThreadPoolExecutor
+from collections import defaultdict
+from concurrent.futures import Future, ThreadPoolExecutor, wait
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -16,6 +22,10 @@ logger = logging.getLogger(__name__)
 CLIPS_DIR = Path("/tmp/vt_clips")
 PADDING_BEFORE_S = 1.0  # seconds before first detection
 PADDING_AFTER_S = 0.5   # seconds after last detection
+# Bounded wait when draining in-flight ffmpeg on cleanup. Each ffmpeg call has
+# its own 30s subprocess timeout, so the worst case is a single slow job; we
+# don't want to block the API thread for that long.
+CLEANUP_DRAIN_TIMEOUT_S = 5.0
 
 
 class ClipExtractor:
@@ -31,6 +41,32 @@ class ClipExtractor:
         self._status: dict[str, str] = {}  # alert_id -> status
         self._clip_paths: dict[str, Path] = {}  # alert_id -> file path
         self._pool = ThreadPoolExecutor(max_workers=2, thread_name_prefix="clip")
+        # Track in-flight futures per channel so cleanup_channel can drain.
+        self._futures: dict[int, set[Future]] = defaultdict(set)
+
+    def _submit(self, channel_id: int, fn, *args) -> None:
+        """Submit a job to the pool and track its future for cleanup.
+
+        Wraps every ffmpeg job in a try/finally that removes the future
+        from `_futures` regardless of outcome.
+        """
+        with self._lock:
+            futures = self._futures[channel_id]
+
+        def runner():
+            try:
+                fn(*args)
+            except Exception:
+                logger.exception("Clip job crashed")
+
+        fut: Future = self._pool.submit(runner)
+        futures.add(fut)
+
+        def _drop(_f, fset=futures):
+            with self._lock:
+                fset.discard(_f)
+
+        fut.add_done_callback(_drop)
 
     def extract_clips(
         self,
@@ -55,7 +91,8 @@ class ClipExtractor:
             if alert_type == "transit_alert":
                 with self._lock:
                     self._status[alert_id] = "pending"
-                self._pool.submit(
+                self._submit(
+                    channel_id,
                     self._extract_transit_clip,
                     alert_id,
                     source,
@@ -65,7 +102,8 @@ class ClipExtractor:
             elif alert_type == "stagnant_alert":
                 with self._lock:
                     self._status[alert_id] = "pending"
-                self._pool.submit(
+                self._submit(
+                    channel_id,
                     self._extract_stagnant_frame,
                     alert_id,
                     source,
@@ -90,14 +128,24 @@ class ClipExtractor:
         if alert_type == "transit_alert":
             with self._lock:
                 self._status[alert_id] = "pending"
-            self._pool.submit(
-                self._extract_transit_clip, alert_id, source, alert, clip_dir
+            self._submit(
+                channel_id,
+                self._extract_transit_clip,
+                alert_id,
+                source,
+                alert,
+                clip_dir,
             )
         elif alert_type == "stagnant_alert":
             with self._lock:
                 self._status[alert_id] = "pending"
-            self._pool.submit(
-                self._extract_stagnant_frame, alert_id, source, alert, clip_dir
+            self._submit(
+                channel_id,
+                self._extract_stagnant_frame,
+                alert_id,
+                source,
+                alert,
+                clip_dir,
             )
 
     def _extract_transit_clip(
@@ -122,6 +170,12 @@ class ClipExtractor:
 
         output = clip_dir / f"clip_{alert_id}.mp4"
 
+        # Defensive mkdir: if cleanup_channel raced our submission and rmtree'd
+        # the dir, this recreates it so ffmpeg has somewhere to write. Cleanup
+        # of an orphaned clip in the recreated dir happens on the next
+        # cleanup_all (e.g. /pipeline/stop or backend restart).
+        clip_dir.mkdir(parents=True, exist_ok=True)
+
         # Try NVENC first, fall back to libx264
         for codec in ("h264_nvenc", "libx264"):
             cmd = [
@@ -141,7 +195,21 @@ class ClipExtractor:
                 str(output),
             ]
             try:
-                subprocess.run(cmd, check=True, timeout=30)
+                result = subprocess.run(
+                    cmd, check=False, capture_output=True, text=True, timeout=30,
+                )
+                if result.returncode != 0:
+                    stderr_tail = (result.stderr or "").strip()[-300:]
+                    if codec == "h264_nvenc":
+                        logger.debug(
+                            "NVENC unavailable, falling back to libx264: %s",
+                            stderr_tail,
+                        )
+                        continue
+                    logger.warning(
+                        "Clip extraction failed for %s: %s", alert_id, stderr_tail,
+                    )
+                    continue
                 # Reject corrupt files (e.g. 261-byte ftyp-only MP4)
                 if output.exists() and output.stat().st_size > 1024:
                     with self._lock:
@@ -149,18 +217,17 @@ class ClipExtractor:
                         self._status[alert_id] = "ready"
                     logger.info("Clip ready: %s (%s)", alert_id, codec)
                     return
-                else:
-                    logger.warning(
-                        "Clip too small for %s (%d bytes), trying next codec",
-                        alert_id,
-                        output.stat().st_size if output.exists() else 0,
-                    )
-                    continue
-            except (subprocess.CalledProcessError, FileNotFoundError):
-                if codec == "h264_nvenc":
-                    logger.debug("NVENC unavailable, falling back to libx264")
-                    continue
-                logger.warning("Clip extraction failed for %s", alert_id)
+                logger.warning(
+                    "Clip too small for %s (%d bytes), trying next codec",
+                    alert_id,
+                    output.stat().st_size if output.exists() else 0,
+                )
+                continue
+            except FileNotFoundError:
+                logger.warning(
+                    "ffmpeg binary not found — clip extraction unavailable",
+                )
+                break
             except subprocess.TimeoutExpired:
                 logger.warning("Clip extraction timed out for %s", alert_id)
 
@@ -187,6 +254,9 @@ class ClipExtractor:
 
         output = clip_dir / f"frame_{alert_id}.jpg"
 
+        # Defensive mkdir — see _extract_transit_clip for rationale.
+        clip_dir.mkdir(parents=True, exist_ok=True)
+
         cmd = [
             "ffmpeg",
             "-y",
@@ -203,7 +273,19 @@ class ClipExtractor:
             str(output),
         ]
         try:
-            subprocess.run(cmd, check=True, timeout=10)
+            result = subprocess.run(
+                cmd, check=False, capture_output=True, text=True, timeout=10,
+            )
+            if result.returncode != 0:
+                stderr_tail = (result.stderr or "").strip()[-300:]
+                logger.warning(
+                    "Stagnant frame extraction failed for %s: %s",
+                    alert_id,
+                    stderr_tail,
+                )
+                with self._lock:
+                    self._status[alert_id] = "failed"
+                return
             if output.exists() and output.stat().st_size > 100:
                 with self._lock:
                     self._clip_paths[alert_id] = output
@@ -213,12 +295,10 @@ class ClipExtractor:
                 with self._lock:
                     self._status[alert_id] = "failed"
                 logger.warning("Stagnant frame too small for %s", alert_id)
-        except (
-            subprocess.CalledProcessError,
-            FileNotFoundError,
-            subprocess.TimeoutExpired,
-        ):
-            logger.warning("Stagnant frame extraction failed for %s", alert_id)
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            logger.warning(
+                "Stagnant frame extraction failed for %s: %s", alert_id, exc,
+            )
             with self._lock:
                 self._status[alert_id] = "failed"
 
@@ -235,7 +315,32 @@ class ClipExtractor:
             return self._clip_paths.get(alert_id)
 
     def cleanup_channel(self, channel_id: int) -> None:
-        """Remove all clips for a channel and clear status tracking."""
+        """Drain in-flight ffmpeg jobs for this channel, then remove clips.
+
+        The drain step is what prevents the "No such file or directory" race:
+        without it, `shutil.rmtree` would delete `/tmp/vt_clips/<id>/` while
+        ffmpeg is still writing to it.
+        """
+        with self._lock:
+            futures = list(self._futures.get(channel_id, set()))
+            self._futures.pop(channel_id, None)
+
+        # Cancel queued jobs first (no-op for already-running ones), then
+        # wait for in-flight ones to finish. Bounded so a stuck ffmpeg
+        # doesn't hold the API thread forever.
+        for f in futures:
+            f.cancel()
+        if futures:
+            done, not_done = wait(futures, timeout=CLEANUP_DRAIN_TIMEOUT_S)
+            if not_done:
+                logger.warning(
+                    "cleanup_channel(%d): %d clip job(s) still running after %.1fs; "
+                    "rmtree may race them",
+                    channel_id,
+                    len(not_done),
+                    CLEANUP_DRAIN_TIMEOUT_S,
+                )
+
         clip_dir = CLIPS_DIR / str(channel_id)
         if clip_dir.exists():
             shutil.rmtree(clip_dir, ignore_errors=True)
@@ -254,7 +359,25 @@ class ClipExtractor:
                 self._clip_paths.pop(aid, None)
 
     def cleanup_all(self) -> None:
-        """Remove all clips and reset state."""
+        """Drain all in-flight ffmpeg jobs across all channels, then wipe."""
+        with self._lock:
+            all_futures: list[Future] = []
+            for fset in self._futures.values():
+                all_futures.extend(fset)
+            self._futures.clear()
+
+        for f in all_futures:
+            f.cancel()
+        if all_futures:
+            done, not_done = wait(all_futures, timeout=CLEANUP_DRAIN_TIMEOUT_S)
+            if not_done:
+                logger.warning(
+                    "cleanup_all: %d clip job(s) still running after %.1fs; "
+                    "rmtree may race them",
+                    len(not_done),
+                    CLEANUP_DRAIN_TIMEOUT_S,
+                )
+
         if CLIPS_DIR.exists():
             shutil.rmtree(CLIPS_DIR, ignore_errors=True)
         with self._lock:

--- a/backend/pipeline/custom/adapter.py
+++ b/backend/pipeline/custom/adapter.py
@@ -14,7 +14,6 @@ from dataclasses import dataclass, field
 from queue import Empty, Queue
 from typing import Callable
 
-import numpy as np
 
 from backend.pipeline.custom.decoder import NvDecoder
 from backend.pipeline.custom.detector import TRTDetector
@@ -43,6 +42,20 @@ logger = logging.getLogger(__name__)
 
 _MAX_PER_FRAME_DATA = 300  # ring buffer size per track
 
+# Uniform processing rate for all sources. Tracker / stitcher / idle-optimizer
+# all assume 30 FPS internally (see TrackerWrapper.frame_rate, track_buffer=150,
+# IdleOptimizer thresholds), so capping decode→infer→track to 30 FPS makes their
+# implicit time math actually true on 60 FPS sources, halves GPU/CPU work, and
+# leaves the source clip untouched for replay (ffmpeg slices the original file).
+PROCESS_FPS = 30.0
+PROCESS_INTERVAL_MS = 1000.0 / PROCESS_FPS
+
+# Drop-late-frame threshold: if the display thread is more than this far behind
+# real-time, drop the head-of-queue frame and re-anchor. Set generously so brief
+# stalls don't cause visible drops, but small enough that we recover within a
+# second or two from a long stall.
+DISPLAY_LATE_DROP_MS = 100.0
+
 
 @dataclass
 class _ChannelState:
@@ -68,11 +81,24 @@ class _ChannelState:
     inference_interval: int = 1  # 1 = every frame, 15 = idle
     # Current PTS from decoder (ms) — used for per_frame_data timestamps
     current_pts_ms: int = 0
+    # 30 FPS cap: PTS of last frame that passed the rate cap (-1 = none yet).
+    last_processed_pts_ms: int = -1
+    # Last computed tracks list (reused across idle-skipped frames so the
+    # display still updates at full source FPS while inference is sparse).
+    last_tracks: list = field(default_factory=list)
     # Display FIFO — processing pushes rendered frames, display pops at PTS rate
     display_queue: Queue = field(default_factory=lambda: Queue(maxsize=5))
     display_wall_start: float = 0.0  # wall-clock when display started
     display_pts_start: int = -1      # PTS of first displayed frame (ms)
-    # Last frame for Phase 3 replay
+    # Seek epoch: bumped by NvDecoder._restart on Setup-loop seek; the display
+    # thread compares against its own `display_seek_epoch` and re-anchors.
+    seek_epoch: int = 0
+    display_seek_epoch: int = 0
+    # Last clean BGR frame, kept for Phase-3 last-frame persistence. Encoded to
+    # JPEG only on phase transition, not every frame (B3).
+    last_frame_bgr: object | None = None
+    # Backwards-compat: tests still reference `last_frame_jpeg`. We populate it
+    # lazily inside `_persist_last_frame` and otherwise leave it None.
     last_frame_jpeg: bytes | None = None
 
 
@@ -121,6 +147,12 @@ class CustomPipeline:
         engine_path = ensure_engine()
         self._detector = TRTDetector(engine_path)
 
+        # Warm up the GPU paths so the first real frame doesn't pay
+        # one-time costs (TRT lazy module loads, RawKernel NVRTC compile,
+        # cupy memory pool init). Without this the first frame takes
+        # ~150 ms vs ~17 ms steady-state — visible as a startup hitch.
+        self._warmup()
+
         self._running = True
         self._thread = threading.Thread(
             target=self._pipeline_loop, name="custom-pipeline", daemon=True,
@@ -131,6 +163,38 @@ class CustomPipeline:
         )
         self._display_thread.start()
         logger.info("CustomPipeline started")
+
+    def _warmup(self) -> None:
+        """Pay one-time GPU-init costs at startup (B7).
+
+        Runs one dummy preprocess + inference + NV12 colour conversion to
+        force CuPy RawKernel JIT, TensorRT lazy-init, and CUDA module loads.
+        """
+        try:
+            import cupy as cp
+
+            t0 = time.monotonic()
+            dummy_h, dummy_w = 1080, 1920
+            dummy_nv12 = cp.zeros(
+                (dummy_h * 3 // 2, dummy_w), dtype=cp.uint8,
+            )
+            # Trigger NVRTC compile of both colour-conversion kernels.
+            nv12_to_rgb_gpu(dummy_nv12, dummy_h, dummy_w)
+            nv12_to_bgr_gpu(dummy_nv12, dummy_h, dummy_w)
+            # Trigger preprocess + TRT context first-call cost.
+            input_tensor, scale_info = self._preprocess(
+                dummy_nv12, dummy_h, dummy_w,
+            )
+            self._detector.detect(input_tensor, scale_info)
+            cp.cuda.Device(0).synchronize()
+            logger.info(
+                "CustomPipeline warmup completed in %.0f ms",
+                (time.monotonic() - t0) * 1000,
+            )
+        except Exception as exc:
+            # Warmup failures are non-fatal — just means the first real
+            # frame will pay the startup cost as before.
+            logger.warning("Warmup failed (non-fatal): %s", exc)
 
     def stop(self) -> None:
         """Stop pipeline, release all resources."""
@@ -255,17 +319,35 @@ class CustomPipeline:
     # -- Pipeline loop (runs on background thread) --
 
     def _pipeline_loop(self):
-        """Main pipeline loop — decode, infer, track, analytics."""
+        """Main pipeline loop — decode, (rate-cap), infer, track, analytics, render.
+
+        Per iteration: read one frame from each non-Review channel, gate it
+        through the 30 FPS rate cap, then process. The pipeline thread blocks
+        on `display_queue.put` (B17 backpressure) so the decoder is naturally
+        rate-limited to display rate when the source is faster than 30 FPS or
+        when display is gated by the PTS-pacer.
+        """
+        import cupy as cp
+
         while self._running:
             self._drain_transitions()
 
-            # Find channels ready for processing
+            # Find channels with a frame ready to process this iteration
             active = {}
             for ch_id, state in list(self._states.items()):
                 if state.decoder is None:
                     continue
                 if state.phase == ChannelPhase.REVIEW:
                     continue
+
+                # Re-sync rate-cap baseline if the decoder has seeked. We pick
+                # this up here (in addition to the explicit reset on phase
+                # transition) so that Setup-loop seeks don't double-skip the
+                # first post-loop frame.
+                dec_epoch = state.decoder.seek_epoch
+                if dec_epoch != state.seek_epoch:
+                    state.seek_epoch = dec_epoch
+                    state.last_processed_pts_ms = -1
 
                 nv12, pts = state.decoder.read()
                 if nv12 is None:
@@ -275,70 +357,97 @@ class CustomPipeline:
                 state.current_pts_ms = pts
                 state.frame_count += 1
 
-                # Idle optimization: skip inference if idle
+                # 30 FPS rate cap (post-decode). NVDEC still decodes every
+                # frame because H.264 is inter-coded, but we drop alternate
+                # frames before the expensive preprocess/infer/render path.
+                last_pts = state.last_processed_pts_ms
+                if last_pts >= 0 and (pts - last_pts) < PROCESS_INTERVAL_MS - 1:
+                    continue
+                state.last_processed_pts_ms = pts
+
+                # Idle inference skipping: every Nth processed frame runs the
+                # detector; in between, we reuse `state.last_tracks` so the
+                # display still gets a frame at the (capped) source rate.
+                run_inference = True
                 if state.inference_interval > 1:
                     if state.infer_count % state.inference_interval != 0:
-                        state.infer_count += 1
-                        continue
+                        run_inference = False
 
-                active[ch_id] = (nv12, pts, state)
+                active[ch_id] = (nv12, pts, state, run_inference)
 
             if not active:
                 time.sleep(0.001)
                 continue
 
-            # Process each channel
-            for ch_id, (nv12, pts, state) in active.items():
+            # Process each channel that passed the rate cap.
+            for ch_id, (nv12, pts, state, run_inference) in active.items():
                 t0 = time.monotonic()
 
-                # GPU preprocess
-                input_tensor, scale_info = self._preprocess(
-                    nv12, state.decoder.height, state.decoder.width,
-                )
+                if run_inference:
+                    # GPU preprocess
+                    input_tensor, scale_info = self._preprocess(
+                        nv12, state.decoder.height, state.decoder.width,
+                    )
 
-                # TRT inference + NMS
-                detections = self._detector.detect(input_tensor, scale_info)
+                    # TRT inference + NMS
+                    detections = self._detector.detect(input_tensor, scale_info)
 
-                # BoT-SORT tracking (pass BGR frame for ReID feature extraction)
-                bgr_frame = None
-                if len(detections) > 0 and state.tracker._with_reid:
-                    import cupy as cp
-                    bgr_gpu = nv12_to_bgr_gpu(nv12, state.decoder.height, state.decoder.width)
-                    bgr_frame = cp.asnumpy(bgr_gpu)
-                tracks = state.tracker.update(detections, frame=bgr_frame)
+                    # Single NV12→BGR conversion shared between ReID extractor
+                    # and renderer (was two separate conversions; B6).
+                    bgr_frame = None
+                    if state.tracker._with_reid and len(detections) > 0:
+                        bgr_gpu = nv12_to_bgr_gpu(
+                            nv12, state.decoder.height, state.decoder.width,
+                        )
+                        bgr_frame = cp.asnumpy(bgr_gpu)
+
+                    tracks = state.tracker.update(detections, frame=bgr_frame)
+                    state.last_tracks = tracks
+
+                    # Phase routing: always track, conditionally analyze.
+                    if state.phase == ChannelPhase.ANALYTICS:
+                        self._process_analytics(ch_id, state, tracks)
+
+                    # Idle optimization update — only when we actually inferred.
+                    if state.idle_optimizer:
+                        transition = state.idle_optimizer.update(
+                            num_detections=len(detections),
+                            num_active_tracks=len(state.active_tracks),
+                        )
+                        if transition:
+                            state.inference_interval = (
+                                state.idle_optimizer.recommended_interval
+                                if transition == "idle" else 1
+                            )
+                            mode = "IDLE" if transition == "idle" else "ACTIVE"
+                            logger.info(
+                                "Channel %d: %s mode (interval=%d)",
+                                ch_id, mode, state.inference_interval,
+                            )
+                else:
+                    # Idle skip: reuse last computed tracks; bgr_frame stays
+                    # None (renderer derives BGR from NV12 itself).
+                    tracks = state.last_tracks
+                    bgr_frame = None
 
                 infer_ms = (time.monotonic() - t0) * 1000
                 state.infer_count += 1
 
-                # Phase routing: always track, conditionally analyze
-                if state.phase == ChannelPhase.ANALYTICS:
-                    self._process_analytics(ch_id, state, tracks)
-
-                # Idle optimization update
-                if state.idle_optimizer:
-                    transition = state.idle_optimizer.update(
-                        num_detections=len(detections),
-                        num_active_tracks=len(state.active_tracks),
-                    )
-                    if transition:
-                        state.inference_interval = (
-                            state.idle_optimizer.recommended_interval
-                            if transition == "idle" else 1
-                        )
-                        mode = "IDLE" if transition == "idle" else "ACTIVE"
-                        logger.info(
-                            "Channel %d: %s mode (interval=%d)",
-                            ch_id, mode, state.inference_interval,
-                        )
-
-                # Store latest rendered frame — display thread emits at source FPS
+                # Render + display. Blocking put provides backpressure (B17):
+                # if the display queue is full, the pipeline thread waits
+                # rather than draining the decoder ahead of display.
                 if self._frame_callback:
-                    self._store_display_frame(ch_id, state, nv12, tracks, infer_ms, pts)
+                    self._store_display_frame(
+                        ch_id, state, nv12, bgr_frame, tracks, infer_ms, pts,
+                    )
 
-                # Best-photo crop extraction (RGB — matches BestPhotoTracker convention)
-                if state.best_photo and state.best_photo.pending_crops:
-                    import cupy as cp
-
+                # Best-photo crop extraction (uses RGB; only when there's
+                # actually pending work and we ran inference this frame).
+                if (
+                    run_inference
+                    and state.best_photo
+                    and state.best_photo.pending_crops
+                ):
                     rgb_gpu = nv12_to_rgb_gpu(
                         nv12, state.decoder.height, state.decoder.width,
                     )
@@ -415,6 +524,10 @@ class CustomPipeline:
             state.frame_count = 0
             state.infer_count = 0
             state.inference_interval = 1
+            state.last_processed_pts_ms = -1  # reset 30 FPS rate-cap baseline
+            state.last_tracks = []
+            state.seek_epoch = 0
+            state.display_seek_epoch = 0
             state.display_pts_start = -1  # reset display timeline
 
             # Best-photo tracker
@@ -451,15 +564,27 @@ class CustomPipeline:
             )
 
     def _handle_eos(self, channel_id: int):
-        """Handle end-of-stream for a channel."""
+        """Handle end-of-stream for a channel.
+
+        For YouTube Live in Analytics: trigger async recovery on the first EOS
+        and then *swallow* subsequent EOS calls while recovery is in flight.
+        Without this short-circuit, the pipeline thread loops back into
+        `decoder.read()` (still returning None for an EOS HLS decoder), calls
+        `_handle_eos` again, and the fall-through transitions the channel to
+        Review while recovery is mid-retry — leaving us decoderless when the
+        new HLS URL eventually arrives. (B1.)
+        """
         state = self._states.get(channel_id)
         if state is None:
+            return
+
+        # Recovery already in flight for this channel — don't act on this EOS.
+        if channel_id in self._recovering:
             return
 
         if (
             state.source_type == "youtube_live"
             and state.phase == ChannelPhase.ANALYTICS
-            and channel_id not in self._recovering
         ):
             # YouTube: try recovery before giving up
             self._trigger_recovery(channel_id, "decode returned None (HLS)")
@@ -813,26 +938,30 @@ class CustomPipeline:
         channel_id: int,
         state: _ChannelState,
         nv12,
+        bgr_frame,
         tracks: list[dict],
         infer_ms: float,
         pts: int,
     ):
-        """Render frame and push to display FIFO for real-time playback.
+        """Render annotated frame and push to display FIFO with backpressure.
 
-        If queue is full (processing ahead of display), skip rendering
-        to avoid wasting CPU on frames the display won't show.
+        Reuses the BGR ndarray produced for ReID when available (single
+        NV12→BGR conversion per frame, B6). Caches the clean BGR for Phase-3
+        replay so we don't encode a clean JPEG every frame (B3). Uses a
+        blocking put so the pipeline thread is naturally rate-limited to the
+        display rate when source > 30 FPS or display gates by PTS (B17).
         """
-        if state.display_queue.full():
-            return  # processing ahead — skip render
+        if bgr_frame is None:
+            bgr_frame = self._renderer.decode_nv12(
+                nv12, state.decoder.height, state.decoder.width,
+            )
 
-        bgr_frame = self._renderer.decode_nv12(
-            nv12, state.decoder.height, state.decoder.width,
-        )
+        # Cache the latest clean BGR frame for Phase-3 last-frame persistence.
+        # Encoding a JPEG happens lazily inside _persist_last_frame on phase
+        # transition — not on every frame.
+        state.last_frame_bgr = bgr_frame
 
-        # Save clean frame (no overlays) for Phase 3 frozen-frame replay
-        state.last_frame_jpeg = self._renderer.encode_clean(bgr_frame)
-
-        # Render annotated JPEG (bboxes only — ROI/lines are frontend overlays)
+        # Render annotated JPEG (bboxes only — ROI/lines are frontend overlays).
         annotated_jpeg = self._renderer.annotate_and_encode(bgr_frame, tracks)
 
         det_list = [
@@ -856,23 +985,47 @@ class CustomPipeline:
             phase=state.phase.value,
             idle_mode=state.idle_optimizer.is_idle if state.idle_optimizer else False,
         )
+        # Bounded blocking put: backpressure for the pipeline thread. The
+        # short timeout ensures we drop on permanent display stalls (e.g.
+        # display thread wedged) rather than blocking forever.
         try:
-            state.display_queue.put_nowait(result)
+            state.display_queue.put(result, block=True, timeout=1.0)
         except Exception:
-            pass  # queue full — skip
+            pass
 
     def _display_loop(self):
         """Emit frames to MJPEG clients at real-time PTS rate.
 
         Pops rendered frames from each channel's display FIFO and emits
-        them when wall-clock time matches the frame's PTS. Processing
-        runs at full speed; this thread ensures real-time playback.
+        them when wall-clock time matches the frame's PTS. Two correctness
+        properties beyond simple PTS gating:
+
+        - **Seek-epoch resync (B4)**: when the decoder seeks (Setup loop),
+          the pipeline-side `state.seek_epoch` increments. We compare to our
+          own `state.display_seek_epoch`, drain the now-stale queue, and
+          reset the wall/PTS baseline so the post-loop pass paces correctly.
+
+        - **Drop-late-frame (B2)**: if wall-clock has fallen more than
+          `DISPLAY_LATE_DROP_MS` behind the queued frame's PTS, drop the
+          head and re-anchor. Without this, a transient stall (cold start,
+          GC, etc.) would leave the pacer permanently behind real-time.
         """
         while self._running:
             emitted = False
             now = time.monotonic()
 
             for ch_id, state in list(self._states.items()):
+                # On seek (decoder loop), drain stale frames and reset baseline.
+                if state.display_seek_epoch != state.seek_epoch:
+                    while True:
+                        try:
+                            state.display_queue.get_nowait()
+                        except Empty:
+                            break
+                    state.display_pts_start = -1
+                    state.display_seek_epoch = state.seek_epoch
+                    continue  # re-evaluate next iteration
+
                 if state.display_queue.empty():
                     continue
 
@@ -882,20 +1035,31 @@ class CustomPipeline:
                 except (IndexError, AttributeError):
                     continue
 
-                # Initialize PTS baseline on first frame
+                # Initialize PTS baseline on first frame after start/seek.
                 if state.display_pts_start < 0:
                     state.display_pts_start = result.timestamp_ms
                     state.display_wall_start = now
 
-                # Check if it's time to show this frame
                 video_elapsed_ms = result.timestamp_ms - state.display_pts_start
                 wall_elapsed_ms = (now - state.display_wall_start) * 1000
+
+                # Drop-late-frame: if we're significantly behind real-time,
+                # skip this frame and re-anchor on the next one. This keeps
+                # cumulative drift bounded regardless of pipeline jitter.
+                if wall_elapsed_ms - video_elapsed_ms > DISPLAY_LATE_DROP_MS:
+                    try:
+                        state.display_queue.get_nowait()
+                    except Empty:
+                        continue
+                    state.display_pts_start = -1  # re-anchor on next frame
+                    emitted = True
+                    continue
 
                 if wall_elapsed_ms >= video_elapsed_ms:
                     # Time to emit — pop from queue
                     try:
                         result = state.display_queue.get_nowait()
-                    except Exception:
+                    except Empty:
                         continue
                     self._safe_callback(self._frame_callback, result)
                     emitted = True
@@ -931,19 +1095,36 @@ class CustomPipeline:
         cleanup_channel_snapshots(channel_id)
 
     def _persist_last_frame(self, channel_id: int) -> None:
-        """Save the last rendered frame to disk for Phase 3 frozen-frame replay."""
+        """Save the last rendered frame to disk for Phase 3 frozen-frame replay.
+
+        Encodes JPEG from the cached BGR ndarray. This is the single
+        encode_clean call per channel lifetime — it used to fire on every
+        frame just so the most recent one would be on disk (B3).
+        """
         from pathlib import Path
 
         state = self._states.get(channel_id)
-        if state is None or not isinstance(state.last_frame_jpeg, bytes):
+        if state is None:
+            return
+
+        # Prefer the cached BGR (current path); fall back to a pre-existing
+        # JPEG if a test or reconnect-flow stored one directly.
+        jpeg: bytes | None = None
+        if state.last_frame_bgr is not None:
+            jpeg = self._renderer.encode_clean(state.last_frame_bgr)
+            state.last_frame_jpeg = jpeg
+        elif isinstance(state.last_frame_jpeg, bytes):
+            jpeg = state.last_frame_jpeg
+
+        if jpeg is None:
             return
 
         frame_dir = Path("snapshots") / str(channel_id)
         frame_dir.mkdir(parents=True, exist_ok=True)
         frame_path = frame_dir / "last_frame.jpg"
-        frame_path.write_bytes(state.last_frame_jpeg)
+        frame_path.write_bytes(jpeg)
         logger.info(
-            "Channel %d: persisted last frame (%d bytes)", channel_id, len(state.last_frame_jpeg),
+            "Channel %d: persisted last frame (%d bytes)", channel_id, len(jpeg),
         )
 
     def _safe_callback(self, callback, *args):

--- a/backend/pipeline/custom/decoder.py
+++ b/backend/pipeline/custom/decoder.py
@@ -51,6 +51,10 @@ class NvDecoder:
         self._nv12_height = int(self._height * 3 // 2)
         self._frame_buffer: list[tuple[cp.ndarray, int]] = []
         self._eos = False
+        # Seek epoch is bumped every time the demuxer is rewound (Setup loop).
+        # Consumers can compare to detect "decoder seeked" without inspecting
+        # PTS deltas — see CustomPipeline._pipeline_loop / _display_loop.
+        self._seek_epoch = 0
 
         logger.info(
             "NvDecoder: %s (%dx%d @ %.1ffps, loop=%s, hls=%s)",
@@ -166,11 +170,13 @@ class NvDecoder:
         return owned, pts_ms
 
     def _restart(self):
-        """Seek to beginning for loop mode."""
+        """Seek to beginning for loop mode. Bumps seek_epoch so consumers
+        can re-anchor their PTS-pacing baselines."""
         self._demuxer.Seek(0)
         self._eos = False
         self._frame_buffer.clear()
-        logger.debug("NvDecoder: looping %s", self._source[:80])
+        self._seek_epoch += 1
+        logger.debug("NvDecoder: looping %s (epoch=%d)", self._source[:80], self._seek_epoch)
 
     def reconnect(self, new_source: str) -> None:
         """Reconnect to a new HLS URL (for stream recovery).
@@ -230,3 +236,10 @@ class NvDecoder:
     @property
     def is_hls(self) -> bool:
         return self._is_hls
+
+    @property
+    def seek_epoch(self) -> int:
+        """Monotonically increasing counter; incremented every time the
+        decoder is rewound to the start of the source (Setup-phase loop).
+        Consumers compare against a previous value to detect a seek."""
+        return self._seek_epoch

--- a/backend/pipeline/deepstream/adapter.py
+++ b/backend/pipeline/deepstream/adapter.py
@@ -39,14 +39,20 @@ class CleanFrameExtractor(BufferOperator):
     """Pre-OSD probe that captures clean frames (no bounding box overlays).
 
     Used for best-photo crops and last-frame capture. Runs every frame
-    (not rate-limited) because best-photo needs to check every frame for
-    pending crops.
+    because best-photo needs to check every frame for pending crops; but
+    only **caches** the most recent clean BGR ndarray. JPEG encoding for
+    Phase-3 last-frame replay is deferred to phase transition (see
+    `DeepStreamPipeline._persist_last_frame`), saving ~5-10 ms of CPU per
+    frame that was previously spent encoding a JPEG nobody reads until
+    Review (B14, mirrors custom-backend B3).
     """
 
     def __init__(self, reporter: TrackingReporter):
         super().__init__()
         self._reporter = reporter
-        self.last_frame: bytes | None = None  # most recent clean JPEG
+        # Most recent clean BGR ndarray (numpy). Encoded to JPEG lazily on
+        # phase transition. None until we've seen at least one frame.
+        self.last_frame_bgr = None
 
     def handle_buffer(self, buffer):
         try:
@@ -63,17 +69,23 @@ class CleanFrameExtractor(BufferOperator):
                 if best_photo and best_photo.pending_crops:
                     best_photo.extract_crops(frame)
 
-                # Keep most recent clean frame as JPEG for Phase 3 replay
-                frame_bgr = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
-                _, jpeg_buf = cv2.imencode(
-                    ".jpg", frame_bgr, [cv2.IMWRITE_JPEG_QUALITY, 80]
-                )
-                self.last_frame = jpeg_buf.tobytes()
+                # Cache most recent BGR for Phase-3 replay; encode lazily.
+                self.last_frame_bgr = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
 
             return True
         except Exception as e:
             logger.error("CleanFrameExtractor: %s", e)
             return True
+
+    def encode_last_frame_jpeg(self) -> bytes | None:
+        """Encode the cached clean BGR to JPEG. Called once on phase change."""
+        if self.last_frame_bgr is None:
+            return None
+        import cv2
+        ok, jpeg_buf = cv2.imencode(
+            ".jpg", self.last_frame_bgr, [cv2.IMWRITE_JPEG_QUALITY, 80]
+        )
+        return jpeg_buf.tobytes() if ok else None
 
 
 class MjpegExtractor(BufferOperator):
@@ -743,16 +755,26 @@ class DeepStreamPipeline:
             self._safe_callback(self._on_pipeline_error, msg_str)
 
     def _on_pipeline_error(self, error_msg: str) -> None:
-        """Handle GStreamer errors — trigger recovery for YouTube sources."""
-        # Find YouTube channels in ANALYTICS that might need recovery
-        for channel_id, state in self._states.items():
+        """Handle GStreamer errors — trigger recovery for *all* matching
+        YouTube/Analytics channels (B9).
+
+        A pipeline-level error (e.g. GPU OOM, decoder failure) generally
+        affects every source on the shared pipeline, so recovering only the
+        first one would leave the rest stuck in Analytics with a dead
+        pipeline. We snapshot the channel list first because
+        `_trigger_recovery` mutates `self._recovering` and may schedule
+        callbacks that mutate `self._states`.
+        """
+        candidates = [
+            cid for cid, state in self._states.items()
             if (
                 state.source_type == "youtube_live"
                 and state.phase == ChannelPhase.ANALYTICS
-                and channel_id not in self._recovering
-            ):
-                self._trigger_recovery(channel_id, error_msg)
-                break  # Handle one channel at a time
+                and cid not in self._recovering
+            )
+        ]
+        for channel_id in candidates:
+            self._trigger_recovery(channel_id, error_msg)
 
     def _trigger_recovery(self, channel_id: int, reason: str) -> None:
         """Start async recovery for a YouTube Live channel."""
@@ -915,13 +937,15 @@ class DeepStreamPipeline:
         self._ws_broadcaster = broadcaster
 
     def _persist_last_frame(self, channel_id: int) -> None:
-        """Save the last clean frame to disk for Phase 3 replay."""
+        """Save the last clean frame to disk for Phase 3 replay.
+
+        Encodes JPEG from the BGR ndarray cached by `CleanFrameExtractor`
+        (was encoded eagerly every frame; B14).
+        """
         state = self._states.get(channel_id)
-        if state is None:
+        if state is None or state.clean_extractor is None:
             return
-        jpeg = None
-        if state.clean_extractor and state.clean_extractor.last_frame:
-            jpeg = state.clean_extractor.last_frame
+        jpeg = state.clean_extractor.encode_last_frame_jpeg()
         if not isinstance(jpeg, bytes):
             return
 

--- a/backend/pipeline/shared.py
+++ b/backend/pipeline/shared.py
@@ -11,15 +11,12 @@ Extracts common logic to avoid duplication across backends:
 
 import asyncio
 import logging
-import os
 import shutil
 from pathlib import Path
 
 import cv2
-import numpy as np
 
 from backend.pipeline.direction import (
-    DirectionStateMachine,
     LineSeg,
     check_line_crossing,
     classify_crossing,

--- a/backend/tests/custom/test_stream_recovery_custom.py
+++ b/backend/tests/custom/test_stream_recovery_custom.py
@@ -1,7 +1,5 @@
 """Stream recovery tests for the custom pipeline."""
 
-import threading
-import time
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/experiments/exp_e2e_fps.py
+++ b/experiments/exp_e2e_fps.py
@@ -1,0 +1,135 @@
+"""End-to-end achieved-FPS measurement on a real MP4 through the full
+custom pipeline path. Mirrors what _pipeline_loop does per frame, so
+the measured rate is what the display pacer would see.
+
+Reports rolling FPS so we can see the warmup transient vs steady state.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import cupy as cp
+import cv2
+import numpy as np
+
+from backend.pipeline.custom.decoder import NvDecoder
+from backend.pipeline.custom.detector import TRTDetector
+from backend.pipeline.custom.preprocess import GpuPreprocessor, nv12_to_bgr_gpu
+from backend.pipeline.custom.tracker import TrackerWrapper
+
+VIDEO_DIR = Path("/data/site_videos") if Path("/data/site_videos").exists() else Path("data_collection/site_videos")
+ENGINE = "/app/models/yolov8s_rfdetr_v1_cont_custom.engine"
+
+JPEG_PARAMS = [cv2.IMWRITE_JPEG_QUALITY, 80]
+
+
+def time_path(label: str, mp4: Path, n_frames: int = 240, with_extra_clean_jpeg: bool = True):
+    print(f"\n## {label}: {mp4.name}")
+    decoder = NvDecoder(str(mp4), loop=False, channel_id=99)
+    detector = TRTDetector(ENGINE)
+    preprocess = GpuPreprocessor()
+    tracker = TrackerWrapper()
+
+    stage = {"decode": [], "preprocess": [], "infer": [], "track": [], "render": [], "total": []}
+    fps_window = []
+    t_start = time.perf_counter()
+
+    for i in range(n_frames):
+        t0 = time.perf_counter()
+
+        # --- decode ---
+        td0 = time.perf_counter()
+        nv12, pts = decoder.read()
+        if nv12 is None:
+            print(f"  EOS at frame {i}")
+            break
+        stage["decode"].append((time.perf_counter() - td0) * 1000)
+
+        # --- preprocess ---
+        tp0 = time.perf_counter()
+        cp.cuda.Device(0).synchronize()
+        input_tensor, scale_info = preprocess(nv12, decoder.height, decoder.width)
+        cp.cuda.Device(0).synchronize()
+        stage["preprocess"].append((time.perf_counter() - tp0) * 1000)
+
+        # --- infer + NMS ---
+        ti0 = time.perf_counter()
+        detections = detector.detect(input_tensor, scale_info)
+        stage["infer"].append((time.perf_counter() - ti0) * 1000)
+
+        # --- BGR for ReID + track ---
+        tt0 = time.perf_counter()
+        bgr_for_reid = None
+        if len(detections) > 0 and tracker._with_reid:
+            bgr_gpu = nv12_to_bgr_gpu(nv12, decoder.height, decoder.width)
+            bgr_for_reid = cp.asnumpy(bgr_gpu)
+        tracks = tracker.update(detections, frame=bgr_for_reid)
+        stage["track"].append((time.perf_counter() - tt0) * 1000)
+
+        # --- render: same pattern as _store_display_frame ---
+        tr0 = time.perf_counter()
+        bgr_gpu_render = nv12_to_bgr_gpu(nv12, decoder.height, decoder.width)
+        bgr = cp.asnumpy(bgr_gpu_render)
+        if with_extra_clean_jpeg:
+            _, _ = cv2.imencode(".jpg", bgr, JPEG_PARAMS)  # encode_clean (last_frame)
+        for t in tracks:
+            x, y, w, h = t["bbox"]
+            tid = t["track_id"]
+            conf = t["confidence"]
+            cv2.rectangle(bgr, (x, y), (x + w, y + h), (0, 255, 0), 2)
+            cv2.putText(bgr, f"#{tid} {conf:.2f}", (x, y - 8),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 255, 0), 1)
+        _, _ = cv2.imencode(".jpg", bgr, JPEG_PARAMS)  # annotated
+        stage["render"].append((time.perf_counter() - tr0) * 1000)
+
+        total_ms = (time.perf_counter() - t0) * 1000
+        stage["total"].append(total_ms)
+
+        # rolling 1-second FPS
+        now = time.perf_counter()
+        fps_window.append(now)
+        fps_window = [t for t in fps_window if now - t <= 1.0]
+        if (i + 1) % 30 == 0 or i < 5:
+            print(f"  frame {i+1:>3}: total={total_ms:6.2f} ms, "
+                  f"rolling FPS≈{len(fps_window)}, dets={len(detections)}, tracks={len(tracks)}")
+
+    decoder.release()
+    elapsed = time.perf_counter() - t_start
+    n = len(stage["total"])
+    print(f"\n  achieved FPS over {n} frames: {n/elapsed:.1f}")
+
+    import statistics
+
+    print("  per-stage medians (ms):", {k: round(statistics.median(v), 2) for k, v in stage.items() if v})
+    # warmup vs steady (skip first 30)
+    if n >= 60:
+        warm = stage["total"][:30]
+        steady = stage["total"][30:]
+        print(f"  first  30 frames mean total: {sum(warm)/30:.2f} ms")
+        print(f"  later     frames mean total: {sum(steady)/len(steady):.2f} ms")
+
+
+def main():
+    print("=" * 70)
+    print("E2E ACHIEVED FPS — full custom pipeline replication")
+    print("=" * 70)
+
+    # 60 fps file
+    mp4_60 = next((p for p in sorted(VIDEO_DIR.glob("*.mp4")) if "Lytle" not in p.name), None)
+    # 30 fps file
+    mp4_30 = next(VIDEO_DIR.glob("*Lytle*.mp4"), None)
+
+    if mp4_60:
+        time_path("60 FPS source — current path (2 JPEG encodes)", mp4_60, n_frames=180)
+    if mp4_30:
+        time_path("30 FPS source — current path (2 JPEG encodes)", mp4_30, n_frames=180)
+
+    # what if we drop the redundant clean-JPEG?
+    if mp4_60:
+        time_path("60 FPS source — proposed path (1 JPEG encode)", mp4_60, n_frames=180, with_extra_clean_jpeg=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/exp_perf_audit.py
+++ b/experiments/exp_perf_audit.py
@@ -1,0 +1,232 @@
+"""Measure per-stage latency of the custom pipeline hot path.
+
+Confirms (or refutes) the hypothesis that the slow MP4 playback in
+Setup/Analytics is bottlenecked by render-thread CPU work, not by
+the GPU detect/track stages. Also probes:
+
+- TRT inference cold-vs-warm gap
+- cupyx.scipy.ndimage.zoom vs cv2 host-side resize (cv2.cuda is not
+  available in the custom image so we compare CPU resize as the
+  realistic alternative)
+- nv12_to_bgr + asnumpy cost
+- JPEG encode at 1920x1080
+- PyNvVideoCodec PTS units on a real MP4 (sanity-check the 90kHz divisor)
+
+Run inside the custom backend container via:
+    docker compose ... exec backend python experiments/exp_perf_audit.py
+"""
+
+from __future__ import annotations
+
+import statistics
+import time
+from pathlib import Path
+
+import cupy as cp
+import cv2
+import numpy as np
+import tensorrt as trt
+from cupyx.scipy.ndimage import zoom
+
+from PyNvVideoCodec import CreateDecoder, CreateDemuxer
+
+from backend.pipeline.custom.preprocess import nv12_to_bgr_gpu, GpuPreprocessor
+
+
+VIDEO_DIR = Path("/data/site_videos") if Path("/data/site_videos").exists() else Path("data_collection/site_videos")
+ENGINE = Path("/app/models/yolov8s_rfdetr_v1_cont_custom.engine")
+
+
+def time_block(fn, n=30):
+    fn()  # untimed warmup of caller (not the system, just to populate args)
+    cp.cuda.Device(0).synchronize()
+    samples = []
+    for _ in range(n):
+        cp.cuda.Device(0).synchronize()
+        t0 = time.perf_counter()
+        fn()
+        cp.cuda.Device(0).synchronize()
+        samples.append((time.perf_counter() - t0) * 1000)
+    return samples
+
+
+def stats(samples):
+    return {
+        "min_ms": round(min(samples), 2),
+        "median_ms": round(statistics.median(samples), 2),
+        "p95_ms": round(sorted(samples)[max(0, int(0.95 * len(samples)) - 1)], 2),
+        "max_ms": round(max(samples), 2),
+        "n": len(samples),
+    }
+
+
+def find_mp4(prefer_60fps=True):
+    candidates = sorted(VIDEO_DIR.glob("*.mp4"))
+    if not candidates:
+        raise RuntimeError(f"No mp4 in {VIDEO_DIR}")
+    if prefer_60fps:
+        for c in candidates:
+            if "Lytle" not in c.name:
+                return c
+    return candidates[0]
+
+
+def probe_pts(mp4: Path):
+    print(f"\n## PTS probe on {mp4.name}")
+    demux = CreateDemuxer(str(mp4))
+    dec = CreateDecoder(gpuid=0, codec=demux.GetNvCodecId(), usedevicememory=True)
+    print(f"  declared: {demux.Width()}x{demux.Height()} @ {demux.FrameRate()}fps")
+    pts_raw = []
+    for _ in range(50):
+        pkt = demux.Demux()
+        if pkt.bsl == 0:
+            break
+        for f in dec.Decode(pkt):
+            if hasattr(f, "getPTS"):
+                pts_raw.append(int(f.getPTS()))
+            if len(pts_raw) >= 30:
+                break
+        if len(pts_raw) >= 30:
+            break
+    if len(pts_raw) < 2:
+        print("  (could not collect pts)")
+        return
+    deltas = [pts_raw[i + 1] - pts_raw[i] for i in range(len(pts_raw) - 1)]
+    deltas = [d for d in deltas if d > 0]
+    median_delta = statistics.median(deltas) if deltas else 0
+    print(f"  first 5 raw PTS: {pts_raw[:5]}")
+    print(f"  median PTS delta: {median_delta}")
+    # Interpret: if 90kHz ticks, 60fps → 1500 ticks/frame; 30fps → 3000 ticks/frame.
+    # If microseconds, 60fps → 16667 us/frame.
+    # If milliseconds, 60fps → 16-17 ms/frame.
+    if median_delta:
+        for label, divisor, target_ms in [("90kHz ticks", 90, None), ("microseconds", 1000, None), ("milliseconds", 1, None)]:
+            implied_ms = median_delta / divisor if divisor else median_delta
+            print(f"    if {label}: implied frame interval = {implied_ms:.2f} ms (= {1000/implied_ms:.1f} fps)" if implied_ms else "")
+
+
+def make_dummy_nv12(h=1080, w=1920):
+    return cp.random.randint(0, 255, (h * 3 // 2, w), dtype=cp.uint8)
+
+
+def main():
+    print("=" * 70)
+    print("CUSTOM-PIPELINE HOT-PATH AUDIT")
+    print("=" * 70)
+
+    # 1. PTS units sanity check
+    mp4_60 = find_mp4(prefer_60fps=True)
+    probe_pts(mp4_60)
+    for c in VIDEO_DIR.glob("*Lytle*.mp4"):
+        probe_pts(c)
+        break
+
+    # 2. NV12 → BGR (GPU kernel) + asnumpy
+    print("\n## NV12→BGR GPU kernel + cp.asnumpy (1920x1080)")
+    nv12 = make_dummy_nv12()
+
+    def f_kernel():
+        return nv12_to_bgr_gpu(nv12, 1080, 1920)
+
+    print("  kernel only (no asnumpy):", stats(time_block(f_kernel)))
+
+    def f_kernel_dl():
+        return cp.asnumpy(nv12_to_bgr_gpu(nv12, 1080, 1920))
+
+    print("  kernel + asnumpy        :", stats(time_block(f_kernel_dl)))
+
+    # 3. Preprocess (zoom-based letterbox)
+    print("\n## GpuPreprocessor (NV12→RGB→letterbox 640) — current implementation")
+    pre = GpuPreprocessor(640)
+
+    def f_pre():
+        return pre(nv12, 1080, 1920)
+
+    print("  full preprocess         :", stats(time_block(f_pre)))
+
+    # 3b. Just the cupyx zoom step in isolation
+    rgb = cp.random.rand(1080, 1920, 3).astype(cp.float32)
+    scale_h = 360 / 1080
+    scale_w = 640 / 1920
+
+    def f_zoom():
+        return zoom(rgb, (scale_h, scale_w, 1.0), order=1)
+
+    print("  cupyx ndimage.zoom only :", stats(time_block(f_zoom)))
+
+    # 3c. CPU bilinear via cv2 as a baseline (the easy alternative if cv2.cuda is missing)
+    rgb_cpu = np.random.rand(1080, 1920, 3).astype(np.float32)
+
+    def f_cv2_resize():
+        return cv2.resize(rgb_cpu, (640, 360), interpolation=cv2.INTER_LINEAR)
+
+    samples = []
+    for _ in range(30):
+        t0 = time.perf_counter()
+        f_cv2_resize()
+        samples.append((time.perf_counter() - t0) * 1000)
+    print("  cv2.resize CPU baseline :", stats(samples))
+
+    # 4. JPEG encode (1920x1080 BGR uint8)
+    print("\n## JPEG encode (cv2.imencode quality 80)")
+    bgr = (np.random.rand(1080, 1920, 3) * 255).astype(np.uint8)
+
+    def f_jpeg():
+        return cv2.imencode(".jpg", bgr, [cv2.IMWRITE_JPEG_QUALITY, 80])
+
+    samples = []
+    for _ in range(30):
+        t0 = time.perf_counter()
+        f_jpeg()
+        samples.append((time.perf_counter() - t0) * 1000)
+    print("  per encode              :", stats(samples))
+    print("  → 2 encodes per frame   :", round(2 * statistics.median(samples), 2), "ms")
+
+    # 5. TRT inference cold vs warm
+    if ENGINE.exists():
+        print("\n## TRT inference cold vs warm")
+        trt_logger = trt.Logger(trt.Logger.WARNING)
+        runtime = trt.Runtime(trt_logger)
+        with open(ENGINE, "rb") as f:
+            engine = runtime.deserialize_cuda_engine(f.read())
+        ctx = engine.create_execution_context()
+        in_name = engine.get_tensor_name(0)
+        out_name = engine.get_tensor_name(1)
+        in_shape = (1, 3, 640, 640)
+        out_shape = tuple(engine.get_tensor_shape(out_name))
+        in_buf = cp.ones(in_shape, dtype=cp.float32)
+        out_buf = cp.empty(out_shape, dtype=cp.float32)
+        ctx.set_tensor_address(in_name, in_buf.data.ptr)
+        ctx.set_tensor_address(out_name, out_buf.data.ptr)
+        stream = cp.cuda.Stream()
+
+        # Cold (first run)
+        t0 = time.perf_counter()
+        ctx.execute_async_v3(stream.ptr)
+        stream.synchronize()
+        cold_ms = (time.perf_counter() - t0) * 1000
+        print(f"  cold (1st call)         : {cold_ms:.2f} ms")
+
+        # Warm
+        samples = []
+        for _ in range(30):
+            t0 = time.perf_counter()
+            ctx.execute_async_v3(stream.ptr)
+            stream.synchronize()
+            samples.append((time.perf_counter() - t0) * 1000)
+        print("  warm                    :", stats(samples))
+    else:
+        print(f"\n## TRT engine not found at {ENGINE} — skipping inference timing")
+
+    # 6. Theoretical minimum frame budget
+    print("\n## Source FPS budgets")
+    for fps in (30, 60):
+        print(f"  {fps} FPS → {1000/fps:.2f} ms/frame budget")
+
+    # 7. End-to-end serial estimate based on measured pieces
+    print("\n## Predicted custom-pipeline serial latency per frame")
+    print("  preprocess + (TRT warm) + 2×asnumpy(BGR) + 2×JPEG ≈ sum of medians")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **Custom backend playback** was wrong on both ends of the throughput spectrum: 60 FPS Analytics drifted ~13% behind real-time (67.88 s for 60 s source); 30 FPS Analytics raced through in 13.40 s (4.48× too fast); Setup post-loop ran at 1.88× source. Three bugs in `_pipeline_loop` + `_display_loop` (pipeline had no backpressure on `display_queue`; display pacer never dropped late frames; `display_pts_start` not reset on Setup-loop seek). All three fixed; cap processing at 30 FPS uniformly so the tracker's `frame_rate=30` / `track_buffer=150` math is actually true on 60 FPS sources.
- **Render hot path** burned ~7 ms/frame encoding a clean JPEG nobody read until Review. Cache `last_frame_bgr` and encode once at phase boundary; share the NV12→BGR conversion between ReID and renderer; idle-skip no longer freezes the live feed; warmup TRT and the two CuPy RawKernels at `start()`.
- **HLS recovery** had a fall-through that transitioned a YouTube channel to Review on the second EOS while reconnect was in flight. `_handle_eos` now early-returns when `channel_id in self._recovering`.
- **DeepStream**: same `CleanFrameExtractor` dual-encode pattern fixed (B14); `_on_pipeline_error` now triggers recovery for all matching channels, not just the first (B9).
- **Clip extractor**: `cleanup_channel` / `cleanup_all` were `shutil.rmtree`-ing `/tmp/vt_clips/<id>/` while ffmpeg jobs were still mid-write, surfacing as `Error opening output ...: No such file or directory`. Track `Future` objects per channel; cancel pending + bounded `wait()` before rmtree. Defensive `mkdir` inside each ffmpeg job. Capture ffmpeg stderr so future failures aren't hidden in unattributed log noise.

Closes #113.

## Validation (Playwright e2e on both backends, 1-min site clips)

| metric | before | after |
|---|---|---|
| custom 60 FPS Analytics duration | 67.88 s (1.13×) | **60.72 s (1.01×)** ✓ |
| custom 30 FPS Analytics duration | **13.40 s (4.48× FAST)** | **60.73 s (1.01×)** ✓ |
| custom 30 FPS Setup post-loop FPS | 56.5 (1.88× FAST) | **30.0** ✓ |
| custom 60 FPS Setup display FPS | 56 | **30** (capped) |
| DS 60 FPS Analytics duration | 71.43 s (1.19×) | **61.42 s (1.02×)** ✓ |
| DS 30 FPS Analytics duration | 61.21 s | 61.26 s (no regression) |
| channel-remove during extract | `ENOENT` per alert | drained, clean rmtree |
| `/alert/{id}/replay` (30/30 alerts) | 200 | 200 |

## Test plan

- [x] `make test` passes on both backends (291 passed, 1 skipped)
- [x] `make lint` clean
- [x] Custom backend: 60 FPS clip Setup → Analytics → Review wall-clock matches source duration ±1 s
- [x] Custom backend: 30 FPS clip same flow matches source duration ±1 s
- [x] Custom backend: 30 FPS clip Setup post-loop FPS == source FPS (no overspeed)
- [x] DeepStream backend: both clips Setup → Analytics → Review match source duration ±1 s, no regression
- [x] Clip-extractor cleanup race reproduces deterministically before fix; passes cleanly after fix
- [x] All 30 alerts' `/alert/{id}/replay` return valid MP4 once extraction settles
- [ ] Production smoke test on a real YouTube Live source (recovery flow B1) — couldn't reproduce in this session; behavior verified by code reading + the existing unit tests

## Bugs explicitly **not** in scope (deferred)

- B8 WS broadcaster head-of-line blocking — separate refactor
- B10 DS `_finalize_lost_track` private-attr access — cosmetic
- B11 `set_inference_interval` no-op — design call
- B12 DS rebuilds whole pipeline on channel state change — pyservicemaker-limited
- B13 DS publishes empty bbox over WS — semantic decision
- B15 Custom HLS `_init_hls` blocks pipeline thread on FIFO open — needs gst-process polling redesign

🤖 Generated with [Claude Code](https://claude.com/claude-code)