### PR TITLE
Fix WebSocket head-of-line blocking with per-client queues (B8)

### DIFF
--- a/backend/api/websocket.py
+++ b/backend/api/websocket.py
@@ -1,9 +1,21 @@
-"""WebSocket broadcaster — real-time data push to browser clients."""
+"""WebSocket broadcaster — real-time data push to browser clients.
+
+The fan-out has **per-client** queues + per-client send tasks so a single slow
+client cannot stall delivery to other clients. Each enqueue is fanned out
+synchronously to every matching client's bounded queue (drop-oldest on full),
+and each client's background task pumps its own queue into ``ws.send_text``.
+
+A bounded ``_queue`` tap is kept around for test introspection — every enqueued
+message is recorded there so synchronous tests can ``_queue.get_nowait()``
+after a request to verify the broadcaster received it. The tap is bounded
+(drop-oldest) so it can't leak memory if production code never drains it.
+"""
 
 import asyncio
 import json
 import logging
 import time
+from dataclasses import dataclass, field
 from typing import Any
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
@@ -13,21 +25,46 @@ from backend.pipeline.protocol import FrameResult
 router = APIRouter()
 log = logging.getLogger(__name__)
 
+# Bounded per-client queue. At 30 FPS frame_data on one channel that's ~8 s of
+# buffering before drops, which is generous for normal browser hiccups but
+# small enough that a frozen tab can't accumulate many seconds of stale state.
+_CLIENT_QUEUE_MAXSIZE = 256
+
+# Test-introspection tap. Production never reads this; bounded to prevent
+# unbounded growth in long-running processes.
+_TEST_TAP_MAXSIZE = 1000
+
+
+@dataclass
+class _ClientChannel:
+    """Per-client send pipe: WebSocket + filters + queue + drain task."""
+
+    ws: WebSocket
+    channels: set[int] | None  # None = all channels
+    types: set[str] | None     # None = all message types
+    queue: asyncio.Queue = field(
+        default_factory=lambda: asyncio.Queue(maxsize=_CLIENT_QUEUE_MAXSIZE),
+    )
+    task: asyncio.Task | None = None
+    alive: bool = True
+
 
 class WsBroadcaster:
-    """Broadcast pipeline events to connected WebSocket clients.
+    """Per-client fan-out of pipeline events to connected WebSocket clients.
 
     Pipeline callbacks (called from the pipeline thread) put messages into
-    an asyncio.Queue via call_soon_threadsafe. A background asyncio task
-    drains the queue and sends to all connected clients with optional
-    channel filtering.
+    every matching client's queue via ``call_soon_threadsafe``. A background
+    asyncio task per client pumps that client's queue into ``ws.send_text``.
+    A slow client only loses its own backlog; everyone else is unaffected.
     """
 
     def __init__(self):
-        # (websocket, channel_filter, type_filter) — None means all
-        self._clients: list[tuple[WebSocket, set[int] | None, set[str] | None]] = []
-        self._queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
-        self._drain_task: asyncio.Task | None = None
+        self._clients: list[_ClientChannel] = []
+        # Test-introspection tap: bounded with drop-oldest. Production never
+        # reads from this; tests can ``_queue.get_nowait()`` / ``empty()``.
+        self._queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(
+            maxsize=_TEST_TAP_MAXSIZE,
+        )
         self._loop: asyncio.AbstractEventLoop | None = None
         # Stats tracking for stats_update (per channel)
         self._stats_last_emit: dict[int, float] = {}  # channel_id -> last emit time
@@ -37,19 +74,23 @@ class WsBroadcaster:
         self._stats_inference_ms_sum: dict[int, float] = {}  # channel_id -> sum for avg
 
     async def start(self) -> None:
-        """Start the background drain task."""
+        """Capture the running event loop for cross-thread enqueue."""
         self._loop = asyncio.get_running_loop()
-        self._drain_task = asyncio.create_task(self._drain_loop())
 
     async def stop(self) -> None:
-        """Stop the background drain task."""
-        if self._drain_task:
-            self._drain_task.cancel()
+        """Cancel all per-client tasks and disconnect."""
+        for client in list(self._clients):
+            client.alive = False
+            if client.task is not None:
+                client.task.cancel()
+        # Drain the cancellations
+        tasks = [c.task for c in self._clients if c.task is not None]
+        if tasks:
             try:
-                await self._drain_task
-            except asyncio.CancelledError:
+                await asyncio.gather(*tasks, return_exceptions=True)
+            except Exception:
                 pass
-            self._drain_task = None
+        self._clients.clear()
 
     async def connect(
         self,
@@ -57,25 +98,42 @@ class WsBroadcaster:
         channels: set[int] | None,
         types: set[str] | None = None,
     ) -> None:
-        """Accept a WebSocket and register it for broadcasts."""
+        """Accept a WebSocket and start its per-client send task."""
         await ws.accept()
-        self._clients.append((ws, channels, types))
+        if self._loop is None:
+            try:
+                self._loop = asyncio.get_running_loop()
+            except RuntimeError:
+                self._loop = None
+        client = _ClientChannel(ws=ws, channels=channels, types=types)
+        client.task = asyncio.create_task(self._client_loop(client))
+        self._clients.append(client)
 
     def disconnect(self, ws: WebSocket) -> None:
-        """Remove a WebSocket from the client list."""
-        self._clients = [(w, c, t) for w, c, t in self._clients if w is not ws]
+        """Remove a WebSocket from the client list (idempotent).
+
+        Cancels the client's send task. Safe to call from the websocket
+        route handler on disconnect.
+        """
+        for client in list(self._clients):
+            if client.ws is ws:
+                client.alive = False
+                if client.task is not None:
+                    client.task.cancel()
+                self._clients.remove(client)
+                return
 
     def enqueue(self, message: dict) -> None:
-        """Thread-safe: put a message on the broadcast queue.
+        """Thread-safe: fan ``message`` out to every matching client.
 
-        When called from a non-event-loop thread (e.g. GStreamer pipeline thread),
-        uses call_soon_threadsafe to safely enqueue. When called from the event
-        loop thread or without a running loop (tests), enqueues directly.
+        From a non-event-loop thread (pipeline thread, gst probe, etc) we
+        hop onto the loop via ``call_soon_threadsafe``; from inside the
+        loop or with no loop running (tests) we fan out synchronously.
         """
         if self._loop is not None and self._loop.is_running():
-            self._loop.call_soon_threadsafe(self._queue.put_nowait, message)
+            self._loop.call_soon_threadsafe(self._fanout, message)
         else:
-            self._queue.put_nowait(message)
+            self._fanout(message)
 
     # -- Pipeline callbacks (called from pipeline thread) --
 
@@ -143,36 +201,81 @@ class WsBroadcaster:
 
     # -- Internal --
 
-    async def _drain_loop(self) -> None:
-        """Background task: drain queue and broadcast to clients."""
-        while True:
-            msg = await self._queue.get()
-            await self._broadcast(msg)
+    def _fanout(self, message: dict) -> None:
+        """Synchronous fan-out: record on tap, deliver to every matching client.
 
-    async def _broadcast(self, message: dict) -> None:
-        """Send a message to all matching connected clients."""
+        Per-client delivery uses ``put_nowait`` with drop-oldest semantics so a
+        slow client cannot back-pressure ``enqueue``.
+        """
+        # Test-tap (bounded, drop-oldest).
+        self._put_with_drop(self._queue, message)
+
         msg_channel = message.get("channel")
         msg_type = message.get("type")
-        text = json.dumps(message)
-        dead: list[WebSocket] = []
-        for ws, channel_filter, type_filter in self._clients:
-            # Channel filtering: skip if client subscribed to specific channels
-            # and this message has a channel that doesn't match.
-            # Messages without a channel (e.g. pipeline_event) go to everyone.
-            if channel_filter is not None and msg_channel is not None:
-                if msg_channel not in channel_filter:
-                    continue
-            # Type filtering: skip if client subscribed to specific types
-            # and this message type doesn't match.
-            if type_filter is not None and msg_type is not None:
-                if msg_type not in type_filter:
-                    continue
-            try:
-                await ws.send_text(text)
-            except Exception:
-                dead.append(ws)
-        for ws in dead:
-            self.disconnect(ws)
+        for client in list(self._clients):
+            if not client.alive:
+                continue
+            # Channel filter — messages with no channel (pipeline_event etc.)
+            # always pass.
+            if (
+                client.channels is not None
+                and msg_channel is not None
+                and msg_channel not in client.channels
+            ):
+                continue
+            # Type filter — messages with no type always pass.
+            if (
+                client.types is not None
+                and msg_type is not None
+                and msg_type not in client.types
+            ):
+                continue
+            self._put_with_drop(client.queue, message)
+
+    @staticmethod
+    def _put_with_drop(q: asyncio.Queue, item: Any) -> None:
+        """``put_nowait`` with drop-oldest fallback when the queue is full."""
+        try:
+            q.put_nowait(item)
+            return
+        except asyncio.QueueFull:
+            pass
+        try:
+            q.get_nowait()
+        except asyncio.QueueEmpty:
+            pass
+        try:
+            q.put_nowait(item)
+        except asyncio.QueueFull:
+            # Should not happen — the queue had room after the get above —
+            # but stay silent if a concurrent producer beat us to it.
+            pass
+
+    async def _client_loop(self, client: _ClientChannel) -> None:
+        """Drain a single client's queue and forward to its WebSocket.
+
+        Survives ``send_text`` errors by marking the client dead and removing
+        it from the broadcaster — one bad consumer cannot stall any other.
+        """
+        try:
+            while client.alive:
+                message = await client.queue.get()
+                try:
+                    await client.ws.send_text(json.dumps(message))
+                except Exception:
+                    client.alive = False
+                    self._remove_client(client)
+                    return
+        except asyncio.CancelledError:
+            return
+
+    def _remove_client(self, client: _ClientChannel) -> None:
+        """Remove a client (idempotent) without cancelling its task — caller
+        is expected to be inside that task already."""
+        try:
+            self._clients.remove(client)
+        except ValueError:
+            pass
 
 
 @router.websocket("/ws")

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -394,47 +394,38 @@ class TestWsBroadcaster:
         assert msg["type"] == "pipeline_event"
         assert msg["event"] == "stopped"
 
-    def test_broadcast_filters_by_channel(self):
-        """Verify _broadcast respects channel filtering."""
-        import asyncio
-        from unittest.mock import AsyncMock, MagicMock
-        from backend.api.websocket import WsBroadcaster
+    def test_fanout_filters_by_channel(self):
+        """Per-client fan-out respects channel filtering."""
+        from unittest.mock import MagicMock
+        from backend.api.websocket import WsBroadcaster, _ClientChannel
 
         broadcaster = WsBroadcaster()
 
-        # Create mock WS clients
+        # Two simulated clients: one unfiltered, one channel-0-only.
         ws_all = MagicMock()
-        ws_all.send_text = AsyncMock()
+        client_all = _ClientChannel(ws=ws_all, channels=None, types=None)
         ws_ch0 = MagicMock()
-        ws_ch0.send_text = AsyncMock()
+        client_ch0 = _ClientChannel(ws=ws_ch0, channels={0}, types=None)
+        broadcaster._clients = [client_all, client_ch0]
 
-        broadcaster._clients = [
-            (ws_all, None, None),  # no filter — receives all
-            (ws_ch0, {0}, None),  # only channel 0
-        ]
+        # Fan-out a channel-1 message — only ws_all should receive it.
+        broadcaster._fanout({"type": "track_ended", "channel": 1, "track_id": 5})
 
-        # Broadcast a channel 1 message
-        msg = {"type": "track_ended", "channel": 1, "track_id": 5}
-        asyncio.run(broadcaster._broadcast(msg))
+        assert client_all.queue.qsize() == 1
+        assert client_ch0.queue.qsize() == 0
 
-        # ws_all should receive it, ws_ch0 should NOT
-        ws_all.send_text.assert_called_once()
-        ws_ch0.send_text.assert_not_called()
-
-    def test_broadcast_no_channel_goes_to_all(self):
-        """Messages without a channel field go to all clients."""
-        import asyncio
-        from unittest.mock import AsyncMock, MagicMock
-        from backend.api.websocket import WsBroadcaster
+    def test_fanout_no_channel_goes_to_all(self):
+        """Messages without a channel field reach every client."""
+        from unittest.mock import MagicMock
+        from backend.api.websocket import WsBroadcaster, _ClientChannel
 
         broadcaster = WsBroadcaster()
-
         ws_ch0 = MagicMock()
-        ws_ch0.send_text = AsyncMock()
-        broadcaster._clients = [(ws_ch0, {0}, None)]
+        client_ch0 = _ClientChannel(ws=ws_ch0, channels={0}, types=None)
+        broadcaster._clients = [client_ch0]
 
-        msg = {"type": "pipeline_event", "event": "started", "detail": "test"}
-        asyncio.run(broadcaster._broadcast(msg))
+        broadcaster._fanout(
+            {"type": "pipeline_event", "event": "started", "detail": "test"}
+        )
 
-        # pipeline_event has no channel — should be sent
-        ws_ch0.send_text.assert_called_once()
+        assert client_ch0.queue.qsize() == 1

--- a/backend/tests/test_m3_phase0.py
+++ b/backend/tests/test_m3_phase0.py
@@ -1,8 +1,6 @@
 """Tests for M3 Phase 0: Backend prerequisites for React UI."""
 
-import asyncio
 import time
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -176,59 +174,135 @@ class TestAlertChannelFilter:
 
 
 class TestWsTypesFilter:
+    @staticmethod
+    def _client(broadcaster, channels=None, types=None):
+        from unittest.mock import MagicMock
+        from backend.api.websocket import _ClientChannel
+        c = _ClientChannel(ws=MagicMock(), channels=channels, types=types)
+        broadcaster._clients.append(c)
+        return c
+
     def test_type_filter_allows_matching(self):
         broadcaster = WsBroadcaster()
-        ws = MagicMock()
-        ws.send_text = AsyncMock()
-        broadcaster._clients = [(ws, None, {"transit_alert"})]
-
-        msg = {"type": "transit_alert", "channel": 0, "alert_id": "abc"}
-        asyncio.run(broadcaster._broadcast(msg))
-        ws.send_text.assert_called_once()
+        c = self._client(broadcaster, types={"transit_alert"})
+        broadcaster._fanout({"type": "transit_alert", "channel": 0, "alert_id": "abc"})
+        assert c.queue.qsize() == 1
 
     def test_type_filter_blocks_non_matching(self):
         broadcaster = WsBroadcaster()
-        ws = MagicMock()
-        ws.send_text = AsyncMock()
-        broadcaster._clients = [(ws, None, {"transit_alert"})]
-
-        msg = {"type": "frame_data", "channel": 0, "frame": 1}
-        asyncio.run(broadcaster._broadcast(msg))
-        ws.send_text.assert_not_called()
+        c = self._client(broadcaster, types={"transit_alert"})
+        broadcaster._fanout({"type": "frame_data", "channel": 0, "frame": 1})
+        assert c.queue.qsize() == 0
 
     def test_no_type_filter_receives_all(self):
         broadcaster = WsBroadcaster()
-        ws = MagicMock()
-        ws.send_text = AsyncMock()
-        broadcaster._clients = [(ws, None, None)]
-
+        c = self._client(broadcaster)
         for msg_type in ["frame_data", "transit_alert", "pipeline_event"]:
-            msg = {"type": msg_type}
-            asyncio.run(broadcaster._broadcast(msg))
-        assert ws.send_text.call_count == 3
+            broadcaster._fanout({"type": msg_type})
+        assert c.queue.qsize() == 3
 
     def test_combined_channel_and_type_filter(self):
         broadcaster = WsBroadcaster()
-        ws = MagicMock()
-        ws.send_text = AsyncMock()
-        # Only channel 0 + only transit_alert
-        broadcaster._clients = [(ws, {0}, {"transit_alert"})]
+        c = self._client(broadcaster, channels={0}, types={"transit_alert"})
 
         # Channel 0, transit_alert — should pass
-        asyncio.run(broadcaster._broadcast({"type": "transit_alert", "channel": 0}))
-        assert ws.send_text.call_count == 1
+        broadcaster._fanout({"type": "transit_alert", "channel": 0})
+        assert c.queue.qsize() == 1
 
         # Channel 1, transit_alert — blocked by channel filter
-        asyncio.run(broadcaster._broadcast({"type": "transit_alert", "channel": 1}))
-        assert ws.send_text.call_count == 1
+        broadcaster._fanout({"type": "transit_alert", "channel": 1})
+        assert c.queue.qsize() == 1
 
         # Channel 0, frame_data — blocked by type filter
-        asyncio.run(broadcaster._broadcast({"type": "frame_data", "channel": 0}))
-        assert ws.send_text.call_count == 1
+        broadcaster._fanout({"type": "frame_data", "channel": 0})
+        assert c.queue.qsize() == 1
 
     def test_ws_endpoint_parses_types_param(self, client):
         with client.websocket_connect("/ws?types=transit_alert,stagnant_alert"):
             pass
+
+
+class TestWsHeadOfLineIsolation:
+    """A slow WS client must not block delivery to fast clients (B8)."""
+
+    def test_slow_client_does_not_starve_fast_client(self):
+        """One client whose send_text is artificially slow should not delay
+        the queue of another client. Each client owns its own queue + task,
+        so the fast client's queue receives the message synchronously inside
+        ``_fanout`` regardless of the slow one's progress."""
+        from unittest.mock import MagicMock
+        from backend.api.websocket import WsBroadcaster, _ClientChannel
+
+        broadcaster = WsBroadcaster()
+        slow = _ClientChannel(ws=MagicMock(), channels=None, types=None)
+        fast = _ClientChannel(ws=MagicMock(), channels=None, types=None)
+        broadcaster._clients = [slow, fast]
+
+        # Don't start tasks — just verify the synchronous fan-out step puts
+        # the message in BOTH queues even if the slow client never drains.
+        for i in range(50):
+            broadcaster._fanout({"type": "frame_data", "frame": i})
+
+        assert slow.queue.qsize() == 50
+        assert fast.queue.qsize() == 50
+
+    def test_slow_client_drops_oldest_when_full(self):
+        """When a single client's queue fills up, the broadcaster drops the
+        oldest message from THAT client's queue only — without affecting any
+        other client or back-pressuring producers."""
+        from unittest.mock import MagicMock
+        from backend.api.websocket import WsBroadcaster, _CLIENT_QUEUE_MAXSIZE, _ClientChannel
+
+        broadcaster = WsBroadcaster()
+        slow = _ClientChannel(ws=MagicMock(), channels=None, types=None)
+        broadcaster._clients = [slow]
+
+        # Push twice the queue's capacity; producers never block.
+        n = _CLIENT_QUEUE_MAXSIZE * 2
+        for i in range(n):
+            broadcaster._fanout({"type": "frame_data", "frame": i})
+
+        # Queue is full but bounded — no exception, no producer stall.
+        assert slow.queue.qsize() == _CLIENT_QUEUE_MAXSIZE
+
+    def test_dead_send_does_not_break_other_clients(self):
+        """If one client's send_text raises (TCP close, etc.), the other
+        client's task continues uninterrupted."""
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock
+        from backend.api.websocket import WsBroadcaster, _ClientChannel
+
+        async def scenario():
+            broadcaster = WsBroadcaster()
+            await broadcaster.start()
+
+            ws_dead = MagicMock()
+            ws_dead.send_text = AsyncMock(side_effect=RuntimeError("connection closed"))
+            ws_alive = MagicMock()
+            ws_alive.send_text = AsyncMock()
+
+            dead_client = _ClientChannel(ws=ws_dead, channels=None, types=None)
+            alive_client = _ClientChannel(ws=ws_alive, channels=None, types=None)
+            dead_client.task = asyncio.create_task(broadcaster._client_loop(dead_client))
+            alive_client.task = asyncio.create_task(broadcaster._client_loop(alive_client))
+            broadcaster._clients = [dead_client, alive_client]
+
+            broadcaster._fanout({"type": "ping"})
+            broadcaster._fanout({"type": "pong"})
+
+            # Give both client tasks a turn to drain their queues.
+            await asyncio.sleep(0.05)
+
+            assert ws_alive.send_text.call_count == 2
+            # Dead client errors out on first send, second message is then
+            # left in its queue (task already exited).
+            assert ws_dead.send_text.call_count == 1
+            assert not dead_client.alive
+            assert dead_client not in broadcaster._clients
+
+            await broadcaster.stop()
+
+        asyncio.run(scenario())
 
 
 # -- phase_changed WS event --


### PR DESCRIPTION
## Summary

\`WsBroadcaster\` used a single shared queue and a serial \`_drain_loop\` that awaited \`ws.send_text\` on each connected client in turn. **One slow client (frozen tab, dev-tools throttling, slow network) blocking on \`await\` froze message delivery to every other client.**

Mirror the pattern \`MjpegBroadcaster\` already uses: per-client \`asyncio.Queue\` (bounded, drop-oldest) + per-client send task. A single slow consumer now only loses its own backlog.

Closes #115.

## What changed

- \`WsBroadcaster._fanout()\` (synchronous) replaces \`_drain_loop\` + \`_broadcast()\` (async). Pipeline-thread \`enqueue()\` still hops onto the loop via \`call_soon_threadsafe\`; from there fan-out is one synchronous put-with-drop-oldest per matching client.
- New \`_ClientChannel\` dataclass holds \`(ws, channels, types, queue, task)\` per client; the broadcaster's \`_clients\` is a \`list[_ClientChannel]\`.
- Per-client \`_client_loop\` task drains the client's queue and forwards to \`ws.send_text\`; on exception the task removes the client and exits — never affects siblings.
- The legacy broadcaster-wide \`_queue\` is kept as a bounded test-introspection tap (every \`enqueue\` records to it; tests can \`_queue.get_nowait()\` synchronously). Bounded with drop-oldest so it can't leak in long-running processes that have no test consumer.

## New tests (\`TestWsHeadOfLineIsolation\`)

- \`test_slow_client_does_not_starve_fast_client\` — stuffing 50 msgs into two clients (one never drains) leaves both queues full at 50; the producer is not gated by the slow consumer.
- \`test_slow_client_drops_oldest_when_full\` — pushing 2× maxsize messages caps the queue at maxsize, no exception, no producer stall.
- \`test_dead_send_does_not_break_other_clients\` — a client whose send_text raises is cleanly removed; the other client's task keeps running.

The pre-existing \`TestWsTypesFilter\` and \`TestWsBroadcaster\` cases that exercised the old \`_broadcast()\` are rewritten to drive the new \`_fanout\` and inspect per-client queues directly.

## Validation

- \`make lint\` clean.
- \`make test\` on **custom**: 363 passed, 9 skipped, 3 pre-existing deepstream-conftest failures.
- \`make test\` on **deepstream**: same — 363/9/3 (pre-existing failures unrelated).
- **Live smoke test** inside the deepstream container: 3 clients (A, B fast; S deliberately stuck for 15 s without reading the socket), 6 \`/pipeline/start\` + 6 \`/pipeline/stop\` pulses. Result: \`{'A': 12, 'B': 12, 'S': 0}\` — fast clients fully unaffected by S's wedged socket. Before this fix, the entire drain loop would have stalled until S's TCP buffer cleared (or never, in this synthetic test).

## Test plan

- [x] Unit tests cover the three meaningful failure modes (slow consumer, full queue, dead client)
- [x] Integration / lifecycle tests still pass (the test-introspection tap preserves the existing \`_queue.get_nowait()\` API)
- [x] Live smoke test verifies HoL isolation against a real WebSocket connection
- [ ] Production rollout: watch \`stats_update\` cadence on the dashboard for a multi-tab session — the previous behavior was that opening a slow second tab would visibly stall stats on the first

🤖 Generated with [Claude Code](https://claude.com/claude-code)