### PR TITLE
Bound HLS init so a failing gst-launch can't deadlock the pipeline (B15)

### DIFF
--- a/backend/pipeline/custom/decoder.py
+++ b/backend/pipeline/custom/decoder.py
@@ -12,12 +12,20 @@ output as local files.
 import logging
 import os
 import subprocess
+import threading
+import time
 
 import cupy as cp
 
 from PyNvVideoCodec import CreateDecoder, CreateDemuxer
 
 logger = logging.getLogger(__name__)
+
+# Bounded wait for gst-launch to begin writing to the FIFO during _init_hls.
+# A real HLS source needs ~1-3 s for DNS + manifest + first segment; this gives
+# generous slack while still failing fast on a misconfig (gst binary missing,
+# codec not present, malformed URL).
+_HLS_INIT_TIMEOUT_S = 15.0
 
 
 class NvDecoder:
@@ -104,9 +112,13 @@ class NvDecoder:
             self._gst_proc.pid,
         )
 
-        # CreateDemuxer blocks on FIFO read until GStreamer starts writing.
-        # Both sides synchronize automatically via the FIFO.
-        self._demuxer = CreateDemuxer(self._fifo_path)
+        # CreateDemuxer's underlying open() on the FIFO blocks until GStreamer
+        # opens the write end. If gst-launch fails to start (binary missing,
+        # codec error, etc.) the writer never appears and CreateDemuxer would
+        # block forever — halting the pipeline thread for every channel. Race
+        # the demuxer-open against gst.poll() so a gst exit surfaces as a
+        # clean RuntimeError instead of a multi-channel deadlock (B15).
+        self._demuxer = self._open_demuxer_with_timeout()
         self._decoder = CreateDecoder(
             gpuid=0,
             codec=self._demuxer.GetNvCodecId(),
@@ -115,6 +127,79 @@ class NvDecoder:
         self._width = self._demuxer.Width()
         self._height = self._demuxer.Height()
         self._fps = self._demuxer.FrameRate()
+
+    def _open_demuxer_with_timeout(self):
+        """Open the FIFO-backed demuxer, racing against gst-launch exit.
+
+        Runs ``CreateDemuxer`` on a worker thread so we can poll
+        ``self._gst_proc`` for early exit. If gst exits before any writer
+        connects, briefly open the FIFO write end ourselves to unblock the
+        demuxer thread (so it doesn't leak as a perpetually-stuck thread)
+        and raise ``RuntimeError`` with the gst stderr tail.
+        """
+        result: dict = {}
+
+        def _open():
+            try:
+                result["demuxer"] = CreateDemuxer(self._fifo_path)
+            except Exception as exc:
+                result["error"] = exc
+
+        t = threading.Thread(
+            target=_open,
+            name=f"hls-demuxer-open-{self._channel_id}",
+            daemon=True,
+        )
+        t.start()
+
+        deadline = time.monotonic() + _HLS_INIT_TIMEOUT_S
+        while time.monotonic() < deadline:
+            if result:
+                break
+            rc = self._gst_proc.poll()
+            if rc is not None:
+                stderr = ""
+                if self._gst_proc.stderr is not None:
+                    try:
+                        stderr = self._gst_proc.stderr.read(4096).decode(
+                            "utf-8", "replace",
+                        )
+                    except Exception:
+                        pass
+                # Unblock the worker so it doesn't outlive us as a stuck
+                # thread holding a FIFO fd.
+                self._unblock_fifo_reader()
+                raise RuntimeError(
+                    "gst-launch exited before HLS source ready "
+                    f"(rc={rc}): {stderr.strip()[-300:]}"
+                )
+            time.sleep(0.05)
+        else:
+            self._unblock_fifo_reader()
+            raise TimeoutError(
+                f"gst-launch did not begin writing within {_HLS_INIT_TIMEOUT_S}s"
+            )
+
+        if "error" in result:
+            raise result["error"]
+        return result["demuxer"]
+
+    def _unblock_fifo_reader(self) -> None:
+        """Briefly open the FIFO write end and close it.
+
+        The blocking ``open(O_RDONLY)`` on the FIFO from CreateDemuxer's
+        worker returns as soon as any writer connects; opening + closing the
+        write side immediately gives it an EOF and lets the worker fall
+        through to its error path instead of leaking forever.
+        """
+        if not self._fifo_path:
+            return
+        try:
+            fd = os.open(self._fifo_path, os.O_WRONLY | os.O_NONBLOCK)
+            os.close(fd)
+        except OSError:
+            # FIFO already gone, or kernel reports no readers — both fine.
+            pass
 
     def read(self) -> tuple[cp.ndarray | None, int]:
         """Decode next frame.

--- a/backend/tests/custom/test_decoder_hls_init.py
+++ b/backend/tests/custom/test_decoder_hls_init.py
@@ -1,0 +1,136 @@
+"""Unit tests for NvDecoder._open_demuxer_with_timeout (B15).
+
+The HLS init path used to block forever on FIFO open if gst-launch failed
+to start. These tests pin the new bounded-wait behavior:
+
+- gst-launch exits before any writer appears → RuntimeError within ~1 s
+- demuxer never returns and gst stays alive → TimeoutError after the
+  bounded wait
+- happy path (demuxer returns quickly) → no error, returns the demuxer
+"""
+
+import os
+import subprocess
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def fake_decoder(tmp_path):
+    """Bare object exposing the attrs _open_demuxer_with_timeout reaches for."""
+    from backend.pipeline.custom.decoder import NvDecoder
+
+    obj = MagicMock(spec=NvDecoder)
+    obj._channel_id = 99
+    obj._fifo_path = str(tmp_path / "vt_fifo")
+    os.mkfifo(obj._fifo_path)
+    # Bind the real methods to our stub so they manipulate obj's attrs.
+    obj._open_demuxer_with_timeout = NvDecoder._open_demuxer_with_timeout.__get__(obj)
+    obj._unblock_fifo_reader = NvDecoder._unblock_fifo_reader.__get__(obj)
+    yield obj
+    if os.path.exists(obj._fifo_path):
+        os.remove(obj._fifo_path)
+
+
+def _block_forever_demuxer(*args, **kwargs):
+    """Stand-in for CreateDemuxer that opens the FIFO read-side and blocks."""
+    fifo = args[0]
+    fd = os.open(fifo, os.O_RDONLY)  # blocks until writer connects
+    os.read(fd, 1)  # then immediately drained on EOF
+    os.close(fd)
+    raise RuntimeError("FIFO closed without producing a stream")
+
+
+def test_gst_exits_early_raises_runtimeerror_fast(fake_decoder):
+    """gst-launch that exits with non-zero RC before connecting → fail fast."""
+    # `false` exits immediately with rc=1; using it as a stand-in for any
+    # gst-launch that fails to start (binary missing, codec error).
+    fake_decoder._gst_proc = subprocess.Popen(
+        ["false"], stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
+    )
+
+    t0 = time.monotonic()
+    with patch(
+        "backend.pipeline.custom.decoder.CreateDemuxer",
+        side_effect=_block_forever_demuxer,
+    ):
+        with pytest.raises(RuntimeError, match="gst-launch exited"):
+            fake_decoder._open_demuxer_with_timeout()
+    elapsed = time.monotonic() - t0
+    assert elapsed < 2.0, f"raised in {elapsed:.2f}s; should be <2s"
+
+
+def test_happy_path_returns_demuxer(fake_decoder):
+    """When CreateDemuxer returns normally, _open_demuxer_with_timeout
+    returns its result (no race-loss on a successful open)."""
+    fake_decoder._gst_proc = subprocess.Popen(
+        ["sleep", "5"], stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
+    )
+    sentinel = object()
+
+    def fast_demuxer(*args, **kwargs):
+        return sentinel
+
+    try:
+        with patch(
+            "backend.pipeline.custom.decoder.CreateDemuxer",
+            side_effect=fast_demuxer,
+        ):
+            assert fake_decoder._open_demuxer_with_timeout() is sentinel
+    finally:
+        fake_decoder._gst_proc.terminate()
+        fake_decoder._gst_proc.wait(timeout=2)
+
+
+def test_timeout_when_neither_side_progresses(fake_decoder, monkeypatch):
+    """gst stays alive but never writes; demuxer also never returns →
+    TimeoutError after the bounded wait. We monkeypatch the timeout to keep
+    the test fast."""
+    monkeypatch.setattr(
+        "backend.pipeline.custom.decoder._HLS_INIT_TIMEOUT_S", 0.5,
+    )
+    fake_decoder._gst_proc = subprocess.Popen(
+        ["sleep", "10"], stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
+    )
+    try:
+        with patch(
+            "backend.pipeline.custom.decoder.CreateDemuxer",
+            side_effect=_block_forever_demuxer,
+        ):
+            with pytest.raises(TimeoutError, match="did not begin writing"):
+                fake_decoder._open_demuxer_with_timeout()
+    finally:
+        fake_decoder._gst_proc.terminate()
+        fake_decoder._gst_proc.wait(timeout=2)
+
+
+def test_unblock_fifo_reader_releases_blocked_open(tmp_path):
+    """_unblock_fifo_reader should release a thread blocked on FIFO open."""
+    from backend.pipeline.custom.decoder import NvDecoder
+
+    obj = MagicMock(spec=NvDecoder)
+    obj._fifo_path = str(tmp_path / "vt_fifo_unblock")
+    os.mkfifo(obj._fifo_path)
+    obj._unblock_fifo_reader = NvDecoder._unblock_fifo_reader.__get__(obj)
+
+    blocked_done = threading.Event()
+
+    def block_on_open():
+        try:
+            fd = os.open(obj._fifo_path, os.O_RDONLY)
+            os.close(fd)
+        finally:
+            blocked_done.set()
+
+    t = threading.Thread(target=block_on_open, daemon=True)
+    t.start()
+    time.sleep(0.1)  # ensure the thread is parked in open()
+    assert not blocked_done.is_set()
+
+    obj._unblock_fifo_reader()
+
+    assert blocked_done.wait(timeout=1.0), "reader should unblock within 1s"
+    os.remove(obj._fifo_path)


### PR DESCRIPTION
## Summary

\`NvDecoder._init_hls\` would block forever if gst-launch failed to start (binary missing, codec unavailable, malformed source URL). \`CreateDemuxer\`'s underlying \`open()\` on the FIFO sits waiting for a writer that never appears, **halting the pipeline thread for every channel**.

Closes #119.

## Fix

Race the demuxer-open against \`gst-launch\` exit on a worker thread with a 15 s ceiling:

- If gst exits before connecting → \`RuntimeError\` with the captured stderr tail.
- If neither progresses within the timeout → \`TimeoutError\`.
- In both error paths, briefly open the FIFO write-end ourselves (\`os.O_WRONLY | os.O_NONBLOCK\`) so the worker's blocked \`open()\` returns and the thread doesn't leak holding a FIFO fd.

## New tests (custom-only — DS container skips them)

- \`test_gst_exits_early_raises_runtimeerror_fast\` — substitute \`/bin/false\` for gst-launch. New behavior raises \`RuntimeError\` within ~2 s; old behavior would have blocked forever.
- \`test_happy_path_returns_demuxer\` — when CreateDemuxer succeeds, we return its result; gst running in the background doesn't race-lose.
- \`test_timeout_when_neither_side_progresses\` — gst alive but silent, demuxer also silent → \`TimeoutError\` after the bounded wait (monkeypatched to 0.5 s for test speed).
- \`test_unblock_fifo_reader_releases_blocked_open\` — direct check that the helper unblocks a parked \`open(O_RDONLY)\`.

## Validation

- \`make lint\` clean.
- \`make test\` on **custom**: 296 passed, 1 skipped, 0 failed (was 292; +4 new tests).
- \`make test\` on **deepstream**: 363 passed, 9 skipped, 0 failed (no regression).

## Test plan

- [x] Unit tests cover all three exit-states (early gst exit, normal demuxer return, timeout)
- [x] FIFO unblock helper has its own focused test
- [x] No regressions in either backend's test suite
- [ ] Production smoke test on a real YouTube Live source — could not reproduce in this session (no live stream available); behavior verified by code reading + the existing recovery test path

🤖 Generated with [Claude Code](https://claude.com/claude-code)