### PR TITLE
Stabilize pipeline destroy after soft-remove (#123 regression fix)

### DIFF
--- a/backend/pipeline/deepstream/adapter.py
+++ b/backend/pipeline/deepstream/adapter.py
@@ -268,6 +268,14 @@ class DeepStreamPipeline:
         the batch router, nullifies callbacks) instead of tearing down and
         rebuilding the entire shared pipeline. Other channels keep
         producing frames at source rate during this operation (B12).
+
+        We do NOT auto-destroy the shared pipeline when the last channel
+        is removed. After every source has been soft-removed, calling
+        pipeline.stop() inside the deferred-stop daemon thread crashes
+        pyservicemaker's C++ side ('terminate called without an active
+        exception', #123). The dormant mux/infer/tracker is harmless;
+        final teardown happens on /pipeline/stop or process exit, which
+        run a different code path that doesn't soft-remove first.
         """
         if channel_id not in self.channels:
             raise KeyError(f"Channel {channel_id} not found")
@@ -275,10 +283,6 @@ class DeepStreamPipeline:
         self._cleanup_channel_snapshots(channel_id)
         del self.channels[channel_id]
         del self._states[channel_id]
-        # If this was the last channel, fully tear the pipeline down so we
-        # don't leave a dormant nvstreammux + nvinfer running.
-        if not self._states:
-            self._destroy_shared_pipeline()
         logger.info("Channel %d removed", channel_id)
 
     def configure_channel(
@@ -636,7 +640,14 @@ class DeepStreamPipeline:
         )
 
     def _destroy_shared_pipeline(self) -> None:
-        """Tear down the shared pipeline."""
+        """Tear down the shared pipeline.
+
+        Mirrors the ``_rebuild_shared_pipeline`` deferred-stop pattern:
+        ``wait()`` first so the pipeline drains to a state where ``stop()``
+        won't crash pyservicemaker's C++ side ('terminate called without an
+        active exception', #123). For HLS sources, ``wait()`` blocks
+        forever — the daemon thread is killed on process exit anyway.
+        """
         if self._shared_pipeline is None:
             return
         import threading as _threading
@@ -647,6 +658,7 @@ class DeepStreamPipeline:
 
         def _deferred_stop():
             try:
+                pipeline.wait()
                 pipeline.stop()
             except Exception:
                 pass

--- a/backend/tests/deepstream/test_deepstream_adapter.py
+++ b/backend/tests/deepstream/test_deepstream_adapter.py
@@ -74,15 +74,13 @@ class TestSharedPipeline:
         assert adapter._states[0].pipeline is adapter._shared_pipeline
         assert adapter._states[1].pipeline is adapter._shared_pipeline
 
-    def test_removing_last_channel_destroys_shared_pipeline(self, adapter, tmp_path):
-        """When the last channel is removed, the shared pipeline is torn down."""
-        adapter.start()
-        v0 = tmp_path / "a.mp4"
-        v0.write_bytes(b"fake")
-        adapter.add_channel(0, str(v0))
-        adapter.remove_channel(0)
-
-        assert adapter._shared_pipeline is None
+    # Note: the previous "remove last channel destroys shared pipeline"
+    # invariant was retired in #123. After every source has been
+    # soft-removed (the post-#122 behaviour), calling pipeline.stop()
+    # crashes pyservicemaker's C++ side. The dormant mux/infer/tracker
+    # is harmless; final teardown happens at /pipeline/stop or process
+    # exit. See TestSoftRemoveOnReview.test_remove_last_channel_keeps_
+    # pipeline_alive for the current invariant.
 
     def test_removing_one_channel_keeps_pipeline_for_others(self, adapter, tmp_path):
         """Removing one channel doesn't affect the shared pipeline if others remain."""
@@ -297,18 +295,28 @@ class TestSoftRemoveOnReview:
         assert 1 in adapter.channels
         assert adapter._states[1].pipeline is pipeline_before
 
-    def test_remove_last_channel_destroys_pipeline(self, adapter, tmp_path):
-        """When the *last* remaining channel is removed, the dormant mux +
-        infer + tracker should be torn down so we don't leak resources."""
+    def test_remove_last_channel_keeps_pipeline_alive(self, adapter, tmp_path):
+        """When the last channel is removed, the shared pipeline stays up
+        in dormant form (mux/infer/tracker waiting for data that won't
+        come). Auto-destroying here crashes pyservicemaker after every
+        source has been soft-removed (#123); the harmless dormant pipeline
+        is cleaned up at /pipeline/stop or process exit instead.
+        """
         adapter.start()
         v1 = tmp_path / "v1.mp4"
         v1.write_bytes(b"fake")
         adapter.add_channel(0, str(v1))
-        assert adapter._shared_pipeline is not None
+        pipeline_before = adapter._shared_pipeline
+        assert pipeline_before is not None
 
         adapter.remove_channel(0)
 
-        assert adapter._shared_pipeline is None
+        # Pipeline kept alive: the source has been soft-removed but the
+        # broader pipeline is the same instance.
+        assert adapter._shared_pipeline is pipeline_before
+        # Channel state is gone from public-facing collections.
+        assert 0 not in adapter.channels
+        assert 0 not in adapter._states
 
 
 class TestCallbacks:


### PR DESCRIPTION
## Bug

After #122 made \`remove_channel\` and \`Analytics→Review\` use \`_soft_remove_source\` instead of rebuilding, calling \`pipeline.stop()\` on a pipeline whose every source has already been soft-removed crashes pyservicemaker's C++ side with \`terminate called without an active exception\`, killing the uvicorn process.

Reproduced during multi-channel e2e validation immediately after #122 merged: add → analytics → auto-Review → remove → process dies. Both \`/channel/remove\` (last channel) and \`/pipeline/stop\` triggered it.

## Fix

Two surgical changes:

- **\`_destroy_shared_pipeline\` now calls \`pipeline.wait()\` before \`pipeline.stop()\`**, mirroring the deferred-stop pattern that \`_rebuild_shared_pipeline\` has been using all along. \`wait()\` drains the pipeline to a state where \`stop()\` can run cleanly. For HLS sources \`wait()\` blocks forever, but the daemon thread is daemon=True so it's reaped on process exit — same trade the rebuild path has always made.

- **\`remove_channel\` no longer auto-destroys** when removing the last channel. The pipeline stays up in dormant form (mux/infer/tracker waiting for data that won't come). Final teardown happens at \`/pipeline/stop\` or process exit. The dormant pipeline costs little; the crash was the actual problem.

## Tests

- Replaced \`test_remove_last_channel_destroys_pipeline\` (asserted #122's now-retired invariant) with \`test_remove_last_channel_keeps_pipeline_alive\`.
- Removed the pre-existing \`test_removing_last_channel_destroys_shared_pipeline\` (asserted the pre-#122 rebuild-on-empty behaviour) with a comment pointing at the new test.

## Validation

- \`make lint\` clean.
- \`make test\` on **deepstream**: 366 passed, 9 skipped, 0 failed.
- \`make test\` on **custom**: 296 passed, 1 skipped, 0 failed.
- Live repro confirmed fixed:
  - Add 1 channel → Analytics → auto-Review → remove → no crash, channel gone, server alive.
  - \`/pipeline/stop\` on dormant pipeline → returns \`{\"status\":\"stopped\"}\`, server alive.
  - \`/pipeline/start\` after stop → fresh channels work normally.

Closes #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)